### PR TITLE
Fix affichage prénom (en cas de multiple noms de famille)

### DIFF
--- a/views/HomeScreen.js
+++ b/views/HomeScreen.js
@@ -392,13 +392,6 @@ function HomeHeader({ navigation, timetable, user }) {
     const words = name.split(' ');
     let prenom = words[words.length - 1];
 
-    for (let i = 1; i < words.length; i++) {
-      if (words[i][0] === words[i][0].toUpperCase()) {
-        prenom = words[i];
-        break; // No need to continue
-      }
-    }
-
     return prenom;
   };
 


### PR DESCRIPTION
Si un utilisateur possède un nom de famille composé (NOM1 NOM2 Prénom), seulement le deuxième nom est affiché sur la page d’accueil (NOM2).
J'ai alors retiré la boucle for qui causait ce "bug". (je ne sais d'ailleurs pas pourquoi elle était là).