### PR TITLE
Fix d'un warning "JSON Parse error: Unexpected token: A"

### DIFF
--- a/fetch/PronoteData/PronoteHomeworks.js
+++ b/fetch/PronoteData/PronoteHomeworks.js
@@ -32,6 +32,7 @@ function getHomeworks(day) {
             method: 'GET'
         })
         .then((response) => response.json())
+        .catch(e=>{console.log("ERR : PronoteHomeworks", e); return [];})
         .then((result) => {
             if (result == 'expired' || result == 'notfound') {
                 return refreshToken().then(() => {
@@ -41,7 +42,10 @@ function getHomeworks(day) {
             else {
                 return result;
             }
-        });
+        }).catch(e=>{
+            console.log(e);
+            return [];
+        })
     });
 }
 


### PR DESCRIPTION
Lors de la navigation dans "Devoirs", un warning s'affichait au chargement `SyntaxError: JSON Parse error: Unexpected token: A`.
Ce cas est prévu et renvoi la valeur par défaut `[]`.