### PR TITLE
fix: Préremplir l'attribue version à "6.6."

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -42,8 +42,7 @@ body:
   - type: input
     attributes:
       label: Version
-      placeholder: '5.0.17 beta'
-      value: '5.0.'
+      value: '6.6.'
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
## Explications des changements
<!-- La deuxième étape consiste à décrire les modifications que vous avez effectué. Soyez clair et précis afin que votre pull request puisse être review rapidement ! -->

L'attribue est pour l'instant prérempli à "5.0." or on est déjà à la version "6.6."
