### PR TITLE
fix: :bug: Actualisation des pages de cours lorsqu'il n'y a pas de cours sous Android

### DIFF
--- a/views/CoursScreen.tsx
+++ b/views/CoursScreen.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useState, useEffect, useRef, useLayoutEffect } from
 import {
   Animated,
   View,
+  Dimensions,
   StyleSheet,
   StatusBar,
   Platform,
@@ -879,9 +880,12 @@ function CoursPage({ cours, navigation, forceRefresh }: {
         <RefreshControl
           refreshing={isHeadLoading}
           onRefresh={onRefresh}
-          colors={[Platform.OS === 'android' ? '#32AB8E' : '']}
+          colors={[Platform.OS === 'android' ? '#0065A8' : '']}
         />
       }
+      contentContainerStyle={{
+        minHeight: Platform.OS === 'android' ? Dimensions.get('window').height - 150 : 0,
+      }}
     >
       {cours.length === 0 && (
         <PapillonLoading


### PR DESCRIPTION
<!-- Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull request (http://docs.getpapillon.xyz/contribute/intro/) -->
## Checklist d'avant pull request
<!-- Tout d'abord merci pour votre pull request ! Il vous reste quelques étapes avant de pouvoir nous proposer vos modifications : -->
<!-- La première étape consiste à remplir la checklist suivante. Pour cocher une case, il suffit de rajouter un "x" entre les crochets ([x] = coché, [ ] = pas coché) -->

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nomage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Cette pull request doit être fusionnée dans la branche `development` (le cas contraire préciser laquelle)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décris ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (par exemple des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Explications des changements
Possibilité d'actualiser la page de cours sur Android même quand il n'y a pas de cours

## Note
Pour que votre pull-request soit fusionnée, vous devez obtenir l'approbation de au moins deux membres de l'équipe dont un coordinateur.
Soyez donc patient :)

### Capture d'écran
![telegram-cloud-photo-size-4-5789644120514478533-y](https://github.com/PapillonApp/Papillon/assets/32978709/618cc29d-f3c4-4e7c-8a9a-a89197c655f3)
