### PR TITLE
fix: icon et titre du menu Exportation/Importation des couleurs des matières

### DIFF
--- a/views/Settings/CoursColor.js
+++ b/views/Settings/CoursColor.js
@@ -259,11 +259,11 @@ const CoursColor = ({ navigation }) => {
                     },
                   },
                   {
-                    menuTitle: 'Importer / exporter',
+                    menuTitle: 'Exporter / Importer',
                     icon: {
                       type: 'IMAGE_SYSTEM',
                       imageValue: {
-                        systemName: 'square.and.arrow.up',
+                        systemName: 'arrow.up.and.down',
                       },
                     },
                     menuItems: [


### PR DESCRIPTION
A la demande de @chevillardanael j'ai modifié l'icône du menu Exporter / Importer ainsi que le nom de ce menu pour inverser les deux termes :
<img width="217" alt="Capture d’écran 2024-04-02 à 19 10 30" src="https://github.com/PapillonApp/Papillon/assets/69359417/06930f31-310c-42a1-98ca-5e8527d559cb">
