### PR TITLE
feat: récupération des contributeurs via l'api GitHub directement

### DIFF
--- a/utils/GetRessources/FormatContribs.ts
+++ b/utils/GetRessources/FormatContribs.ts
@@ -1,0 +1,81 @@
+import { getPapillonContributors } from './GetContribs';
+
+export async function formatPapillonContributors() {
+    const contributors = getPapillonContributors();
+    if (contributors === null) {
+        setTimeout(formatPapillonContributors, 1000);
+        return;
+    }
+
+    const maintaineurs = [
+        {
+            "name": "Vince (ecnivtwelve)",
+            "role": "Fondateur",
+            "avatar": "https://avatars.githubusercontent.com/u/32978709?v=4&s=100",
+            "link": "https://github.com/ecnivtwelve"
+        },
+        {
+            "name": "Lucas (Tryon)",
+            "role": "Mainteneur",
+            "avatar": "https://avatars.githubusercontent.com/u/68423470?v=4&s=100",
+            "link": "https://tryon-lab.fr/"
+        },
+        {
+            "name": "Maël Gangloff",
+            "role": "Mainteneur",
+            "avatar": "https://avatars.githubusercontent.com/u/51171251?v=4",
+            "link": "https://maelgangloff.fr/"
+        },
+        {
+            "name": "Olivier T.",
+            "role": "Mainteneur",
+            "avatar": "https://avatars.githubusercontent.com/u/69359417?v=4",
+            "link": "https://github.com/Vilerio"
+        }
+    ];
+
+    const manualContributors = [
+        {
+            "name": "Anaël (Shidoss)",
+            "role": "Contributeur",
+            "avatar": "https://avatars.githubusercontent.com/u/143846034?v=4",
+            "link": "https://anaelchevillard.com/"
+          },
+    ];
+
+    const excludedContribs = {
+        "Vilerio": true,
+        "maelgangloff": true,
+        "tryon-dev": true,
+        "ecnivtwelve": true,
+        "dependabot[bot]": true
+    };
+
+    const filteredContributors = contributors.filter(contributor => !excludedContribs[contributor.login]);
+
+    const formattedContributors = {
+        lastupdated: new Date().toISOString().split('T')[0],
+        team: [
+            {
+                name: "Mainteneurs",
+                member: maintaineurs
+            },
+            {
+                name: "Contributeurs",
+                member: [
+                    ...filteredContributors.map(contributor => ({
+                        name: contributor.login,
+                        role: "Contributeur",
+                        avatar: contributor.avatar_url,
+                        link: contributor.html_url
+                    })),
+                    ...manualContributors
+                ]
+            }
+        ]
+    };
+
+    return formattedContributors;
+}
+
+formatPapillonContributors();

--- a/utils/GetRessources/GetContribs.ts
+++ b/utils/GetRessources/GetContribs.ts
@@ -1,0 +1,33 @@
+export interface Contributor {
+    login: string;
+    avatar_url: string;
+    html_url: string;
+}
+
+export interface ContributorsResponse {
+    contributors: Contributor[];
+    jsonResponse: any;
+}
+
+let contributorsGlobal: Contributor[] | null = null;
+
+export async function fetchPapillonContributors(): Promise<ContributorsResponse> {
+    const response = await fetch("https://api.github.com/repos/PapillonApp/Papillon/contributors");
+    if (!response.ok) {
+        throw new Error(`Les PapiContributeurs n'ont pas pu être récupérés : ${response.statusText}`);
+    }
+    const jsonResponse = await response.json();
+    const contributors = jsonResponse.map((contributor: any) => ({
+        login: contributor.login,
+        avatar_url: contributor.avatar_url,
+        html_url: contributor.html_url
+    }));
+    contributorsGlobal = contributors;
+    return { contributors, jsonResponse };
+}
+
+export function getPapillonContributors(): Contributor[] | null {
+    return contributorsGlobal;
+}
+
+fetchPapillonContributors();

--- a/views/Settings/AboutScreen.tsx
+++ b/views/Settings/AboutScreen.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react-native';
 
 import packageJson from '../../package.json';
-import { GetRessource } from '../../utils/GetRessources/GetRessources';
+import { formatPapillonContributors } from '../../utils/GetRessources/FormatContribs';
 
 import GetUIColors from '../../utils/GetUIColors';
 
@@ -31,25 +31,17 @@ import NativeItem from '../../components/NativeItem';
 import NativeText from '../../components/NativeText';
 
 function AboutScreen({ navigation }) {
-  const [team, setTeam] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [team, setTeam] = useState(null);
 
   useEffect(() => {
-    setLoading(true);
-    callGetRessource('team')
-      .then(response => {
-        setTeam(response);
-        setLoading(false);
-      })
-      .catch(error => console.error(error));
+    async function fetchContributors() {
+      const team = await formatPapillonContributors();
+      setTeam(team);
+    }
+    fetchContributors();
   }, []);
-
-  function callGetRessource(ressource: string) {
-    return GetRessource(ressource)
-      .then(data => {
-        return data;
-      });
-  }
+  
 
   const UIColors = GetUIColors();
   const theme = useTheme();


### PR DESCRIPTION
- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nomage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Cette pull request doit être fusionnée dans la branche `development` (le cas contraire préciser laquelle)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décris ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (par exemple des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Explications des changements
Les contributeurs sont maintenant récupérés via l'api GitHub, à l'exception d'Anaël, qui est ajouté manuellement, puisqu'il contribue très grandement à l'application sans passer par GitHub (design)

<img width="323" alt="Capture d’écran 2024-04-07 à 15 06 19" src="https://github.com/PapillonApp/Papillon/assets/69359417/ecd98477-35b9-4fbe-94a5-1e0020700d0a">
<img width="323" alt="Capture d’écran 2024-04-07 à 15 06 22" src="https://github.com/PapillonApp/Papillon/assets/69359417/fed8ac69-46ec-4138-bacd-436bb216db6f">
<img width="323" alt="Capture d’écran 2024-04-07 à 15 06 25" src="https://github.com/PapillonApp/Papillon/assets/69359417/31b64f82-fdb9-40fb-be3f-d965a74801f6">


