### PR TITLE
fix:  Changement de "gestion" en "couleur" des matières

### DIFF
--- a/stacks/AppStack.tsx
+++ b/stacks/AppStack.tsx
@@ -82,7 +82,7 @@ const AppStack = ({ navigation }) => {
       name: 'InsetMatieres',
       component: require('../views/Settings/CoursColor').default,
       options: {
-        headerTitle: 'Gestion des matières',
+        headerTitle: 'Couleur des matières',
         presentation: 'modal',
       }
     },

--- a/stacks/SettingsStack.tsx
+++ b/stacks/SettingsStack.tsx
@@ -24,7 +24,7 @@ import TrophiesScreen from '../views/Settings/TrophiesScreen';
 
 function InsetSettings() {
   const UIColors = GetUIColors();
-  
+
   return (
     <Stack.Navigator
       screenOptions={
@@ -70,7 +70,7 @@ function InsetSettings() {
         name="CoursColor"
         component={CoursColor}
         options={{
-          headerTitle: 'Gestion des matières',
+          headerTitle: 'Couleur des matières',
         }}
       />
       <Stack.Screen

--- a/views/SettingsScreen.ios.tsx
+++ b/views/SettingsScreen.ios.tsx
@@ -66,7 +66,7 @@ function NewSettings({ navigation }: {
           backgroundColor="transparent"
         />
       )}
-      
+
       <NativeList
         inset
         sideBar
@@ -265,7 +265,7 @@ function NewSettings({ navigation }: {
           onPress={() => navigation.navigate('CoursColor')}
         >
           <NativeText heading="h4">
-            Gestion des matières
+            Couleur des matières
           </NativeText>
           <NativeText heading="p" style={{opacity: 0.6, fontSize: 15}}>
             Personnalisation des matières


### PR DESCRIPTION
<!-- Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull request (http://docs.getpapillon.xyz/contribute/intro/) -->
## Checklist d'avant pull request
<!-- Tout d'abord merci pour votre pull request ! Il vous reste quelques étapes avant de pouvoir nous proposer vos modifications : -->
<!-- La première étape consiste à remplir la checklist suivante. Pour cocher une case, il suffit de rajouter un "x" entre les crochets ([x] = coché, [ ] = pas coché) -->

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nomage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Cette pull request doit être fusionnée dans la branche `development` (le cas contraire préciser laquelle)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décris ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (par exemple des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Explications des changements
<!-- La deuxième étape consiste à décrire les modifications que vous avez effectué. Soyez clair et précis afin que votre pull request puisse être review rapidement ! -->
Afin d'uniformiser l'interface, le menu Gestion des matières/Couleur des matières a été renommé en Couleur des matières globalement.
Précédemment, sur Android, dans l'accueil des paramètres "couleur" était utilisé et "gestion" une fois le menu ouvert, de ce que j'ai vu dans le code, "gestion" était utilisé partout sur iOS.

### Changelogs proposés
fix:  Replacement de "gestion des matières" par "couleur des matières"

### Informations supplémentaires
J'ai choisi de conserver la formulation "Couleur des matières" car je la trouve plus simple, mais n'hésitez pas à demander si vous préférez l'autre (notamment si ce menu doit avoir une autre utilisation plus tard, par exemple pour masquer des matières).