### PR TITLE
Modals redesign

### DIFF
--- a/views/Devoirs/CreateHomeworkScreen.android.tsx
+++ b/views/Devoirs/CreateHomeworkScreen.android.tsx
@@ -6,12 +6,13 @@ import NativeList from '../../components/NativeList';
 import NativeItem from '../../components/NativeItem';
 import NativeText from '../../components/NativeText';
 import { Alert, BackHandler, Modal, Platform, StatusBar, StyleSheet, TouchableOpacity, View } from "react-native";
-import { CalendarDays, Check, Circle, X } from "lucide-react-native";
+import { CalendarDays, Check, Circle, Pencil, Plus, X } from "lucide-react-native";
 import SyncStorage from "sync-storage";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useActionSheet } from "@expo/react-native-action-sheet";
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { getSavedCourseColor, normalizeCoursName } from "../../utils/cours/ColorCoursName";
+import getClosestGradeEmoji from '../../utils/cours/EmojiCoursName';
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { showMessage } from "react-native-flash-message";
 import { RegisterTrophy } from "../Settings/TrophiesScreen";
@@ -155,17 +156,27 @@ function CreateHomeworkScreenAndroid({ route, navigation }: {
         let subjects = JSON.parse(SyncStorage.get('savedColors'))
         let subjectsObject = Object.keys(subjects)
         const options = subjectsObject.map(key => subjects[key].originalCourseName)
+        const emojis = subjectsObject.map(key => <NativeText>{getClosestGradeEmoji(subjects[key].originalCourseName)}</NativeText>)
         options.push("Créer...")
         options.push("Annuler")
-        const containerStyle = Platform.OS === 'android' ? { paddingBottom: insets.bottom, backgroundColor: UIColors.background } : null;
+        emojis.push(<Plus size={24} color={"#42f55d"}/>)
+        emojis.push(<X size={24} color={"#eb4034"}/>)
+        const containerStyle = Platform.OS === 'android' ? { paddingBottom: insets.bottom, marginTop: insets.top * 4, backgroundColor: UIColors.background, borderTopLeftRadius: 25, borderTopRightRadius: 25 } : null;
         const createButtonIndex = options.length - 2;
         const cancelButtonIndex = options.length - 1;
         showActionSheetWithOptions(
             {
-              options,
-              tintColor: UIColors.primary,
-              containerStyle,
-              cancelButtonIndex: cancelButtonIndex
+                options,
+                tintColor: UIColors.primary,
+                containerStyle,
+                cancelButtonIndex: cancelButtonIndex,
+                icons: emojis,
+                title: "Sélectionner une matière",
+                cancelButtonTintColor: "#eb4034",
+                showSeparators: true,
+                separatorStyle: modalStyles.separator,
+                titleTextStyle: {color: UIColors.text, ...modalStyles.title},
+                textStyle: modalStyles.text
             },
             (buttonIndex) => {
               if (typeof buttonIndex !== 'undefined' && buttonIndex !== cancelButtonIndex) {
@@ -399,6 +410,22 @@ function CreateHomeworkScreenAndroid({ route, navigation }: {
         </View>
     )
 }
+
+const modalStyles = StyleSheet.create({
+    title: {
+        fontSize: 18,
+        textAlign: 'center',
+        width: '100%',
+        fontFamily: 'Papillon-Semibold'
+    },
+    text: {
+        paddingRight: 20,
+    },
+    separator: {
+        backgroundColor: '#fff2',
+        height: 0.5
+    }
+})
 
 const styles = StyleSheet.create({
     input: {

--- a/views/GradesScreen.tsx
+++ b/views/GradesScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
-import { Animated, ActivityIndicator, StatusBar, View, Dimensions, StyleSheet, ScrollView, TouchableOpacity, RefreshControl, Easing, Platform, Pressable } from 'react-native';
+import { Animated, ActivityIndicator, StatusBar, View, Dimensions, StyleSheet, ScrollView, TouchableOpacity, RefreshControl, Easing, Platform, Pressable, BackHandler } from 'react-native';
 
 // Custom imports
 import GetUIColors from '../utils/GetUIColors';
@@ -57,6 +57,7 @@ import { PapillonGrades, PapillonGradesViewAverages } from '../fetch/types/grade
 
 import { calculateSubjectAverage, calculateSubjectMedian } from '../utils/grades/averages';
 import PapillonLoading from '../components/PapillonLoading';
+import { useFocusEffect } from '@react-navigation/native';
 
 const GradesScreen = ({ navigation }: {
   navigation: any // TODO
@@ -73,6 +74,20 @@ const GradesScreen = ({ navigation }: {
     subjectAverageModal.current?.present();
   }, []);
   const [currentSubject, setCurrentSubject] = useState(null);
+
+  const [isSubjectModalShowing, setIsSubjectModalShowing] = useState<boolean>(false);
+  useFocusEffect(useCallback(() => {
+    const onBackPress = () => {
+      if (isSubjectModalShowing) {
+        subjectAverageModal.current?.dismiss()
+        return true;
+      } else {
+        return false;
+      }
+    }
+    BackHandler.addEventListener('hardwareBackPress', onBackPress);
+    return () => BackHandler.removeEventListener('hardwareBackPress', onBackPress)
+  }, [subjectAverageModal, isSubjectModalShowing]))
 
   // Data
   const [hideNotesTab, setHideNotesTab] = React.useState(false);
@@ -492,7 +507,8 @@ const GradesScreen = ({ navigation }: {
       <BottomSheetModal
         ref={subjectAverageModal}
         index={1}
-        snapPoints={['10%', '60%', '90%']}
+        snapPoints={['30%', '60%', '90%']}
+        onChange={idx => setIsSubjectModalShowing(idx > -1)}
 
         style={{
           shadowColor: '#000000',

--- a/views/GradesScreen.tsx
+++ b/views/GradesScreen.tsx
@@ -336,14 +336,20 @@ const GradesScreen = ({ navigation }: {
     const options = periods.map((item) => item.name);
     options.push('Annuler');
     const cancelButtonIndex = options.length - 1;
-    const containerStyle = Platform.OS === 'android' ? { paddingBottom: insets.bottom, backgroundColor: UIColors.background } : null;
+    const containerStyle = Platform.OS === 'android' ? { paddingBottom: insets.bottom, backgroundColor: UIColors.background, borderTopLeftRadius: 25, borderTopRightRadius: 25 } : undefined;
 
     showActionSheetWithOptions(
       {
         options,
         cancelButtonIndex: cancelButtonIndex,
         tintColor: UIColors.primary,
-        containerStyle,
+        containerStyle: containerStyle,
+        cancelButtonTintColor: "#eb4034",
+        title: "Choix de la période",
+        showSeparators: true,
+        separatorStyle: modalStyles.separator,
+        titleTextStyle: {color: UIColors.text, ...modalStyles.title},
+        textStyle: modalStyles.text
       },
       (buttonIndex) => {
         if (typeof buttonIndex !== 'undefined' && buttonIndex !== cancelButtonIndex) {
@@ -1272,6 +1278,22 @@ const styles = StyleSheet.create({
     }
   },
 });
+
+const modalStyles = StyleSheet.create({
+  title: {
+    fontSize: 18,
+    textAlign: 'center',
+    width: '100%',
+    fontFamily: 'Papillon-Semibold'
+  },
+  text: {
+    paddingHorizontal: 16
+  },
+  separator: {
+    backgroundColor: '#fff2',
+    height: 0.5
+  }
+})
 
 const subjectStyles = StyleSheet.create({
   container: {

--- a/views/GradesScreen.tsx
+++ b/views/GradesScreen.tsx
@@ -23,7 +23,7 @@ import formatCoursName from '../utils/cours/FormatCoursName';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 
 // Icons
-import { Users2, File, TrendingDown, TrendingUp, AlertTriangle, MoreVertical, EyeOff, DivideSquare, User } from 'lucide-react-native';
+import { Users2, File, TrendingDown, TrendingUp, MoreVertical, EyeOff, DivideSquare, User, LineChartIcon, X } from 'lucide-react-native';
 import { Stats } from '../interface/icons/PapillonIcons';
 
 // Plugins
@@ -349,9 +349,14 @@ const GradesScreen = ({ navigation }: {
 
   function androidPeriodChangePicker() {
     const options = periods.map((item) => item.name);
+    const icons = periods.map((_i) => <LineChartIcon size={24} color={UIColors.primary}/>);
     options.push('Annuler');
+    icons.push(<X size={24} color={"#eb4034"}/>)
     const cancelButtonIndex = options.length - 1;
-    const containerStyle = Platform.OS === 'android' ? { paddingBottom: insets.bottom, backgroundColor: UIColors.background, borderTopLeftRadius: 25, borderTopRightRadius: 25 } : undefined;
+    const containerStyle = Platform.OS === 'android' ? {
+      paddingBottom: insets.bottom, backgroundColor: UIColors.background,
+      borderTopLeftRadius: 25, borderTopRightRadius: 25 }
+      : undefined;
 
     showActionSheetWithOptions(
       {
@@ -364,7 +369,7 @@ const GradesScreen = ({ navigation }: {
         showSeparators: true,
         separatorStyle: modalStyles.separator,
         titleTextStyle: {color: UIColors.text, ...modalStyles.title},
-        textStyle: modalStyles.text
+        icons: icons
       },
       (buttonIndex) => {
         if (typeof buttonIndex !== 'undefined' && buttonIndex !== cancelButtonIndex) {
@@ -1301,9 +1306,6 @@ const modalStyles = StyleSheet.create({
     textAlign: 'center',
     width: '100%',
     fontFamily: 'Papillon-Semibold'
-  },
-  text: {
-    paddingHorizontal: 16
   },
   separator: {
     backgroundColor: '#fff2',


### PR DESCRIPTION
## Checklist d'avant pull request

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Cette pull request doit être fusionnée dans la branche `development` (le cas contraire préciser laquelle)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (par exemple des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Explications des changements
- Redesign de la modale de sélection de matière pour la création de devoir sur Android.
- Redesign de la modale pour la sélection de la période
- Résolution de l'issue #247 

### Changelogs proposés
- Redesign des modales.
- Possibilité de faire retour de la modale de matière.

## Note
Pour que votre pull-request soit fusionnée, vous devez obtenir l'approbation de au moins deux membres de l'équipe dont un coordinateur.
Soyez donc patient :)

### Informations supplémentaires
<details><summary>Previews</summary>
<p>

| Avant | Après | Description |
|--------|--------|--------|
| ![Screenshot_20240614_235222_Papillon_Dev](https://github.com/PapillonApp/Papillon/assets/73659505/5c702c7c-bd40-406d-ba75-a3fc42df8058) | ![Screenshot_20240614_175102_Papillon_Dev](https://github.com/PapillonApp/Papillon/assets/73659505/1941dbd8-ead7-447d-ad46-68d40b18575d) | Modale de sélection de matière pour l'ajout de devoir sur Android. Ajout d'une icone à chaque matière + pour les boutons d'actions. Ajout d'un titre à la modale + stylisation. Initialement, les marges étaient mal définis, ce qui faisait que la modale dépassait de l'écran. |
| ![Screenshot_20240614_235314_Papillon_Dev](https://github.com/PapillonApp/Papillon/assets/73659505/394cb181-8160-4b98-ab21-e802bd456669) |![Screenshot_20240615_212236_Papillon Dev](https://github.com/PapillonApp/Papillon/assets/73659505/5a96a393-faf4-4818-81b5-32656a47bc76) | Modale de sélection de période. Ajout d'un titre à la modale + stylisation avec des icones. |

Avant:

https://github.com/PapillonApp/Papillon/assets/73659505/f93bab70-10f9-49bb-bc23-f158deb8c629

Après:

https://github.com/PapillonApp/Papillon/assets/73659505/cbe80f07-68e9-4498-8612-b377e41e23aa

Modale de matière. Permettre d'utiliser le bouton retour pour quitter.

</p>
</details> 