### PR TITLE
Update of the Notes Widget on the Papillon home page

### DIFF
--- a/src/stores/grades/index.ts
+++ b/src/stores/grades/index.ts
@@ -8,6 +8,8 @@ export const useGradesStore = create<GradesStore>()(
     (set) => ({
       defaultPeriod: "",
       periods: [],
+      currentPeriod: "",
+
 
       lastUpdated: 0,
       averages: {},
@@ -35,7 +37,8 @@ export const useGradesStore = create<GradesStore>()(
             averages: {
               ...state.averages,
               [periodName]: averages
-            }
+            },
+            currentPeriod: periodName,
           };
         });
       },

--- a/src/stores/grades/types.ts
+++ b/src/stores/grades/types.ts
@@ -6,6 +6,7 @@ export interface GradesStore {
   lastUpdated: number
   defaultPeriod: string
   periods: Period[]
+  currentPeriod: string
 
   grades: { [periodName: string]: Grade[] }
   averages: { [periodName: string]: AverageOverview }

--- a/src/widgets/Components/GeneralAverage.tsx
+++ b/src/widgets/Components/GeneralAverage.tsx
@@ -1,10 +1,9 @@
+
 import { useTheme } from "@react-navigation/native";
 import { PieChart } from "lucide-react-native";
 import React, { forwardRef, useEffect, useImperativeHandle, useMemo } from "react";
 import { Text, View } from "react-native";
-import Reanimated, {
-  LinearTransition
-} from "react-native-reanimated";
+import Reanimated, { LinearTransition } from "react-native-reanimated";
 
 import AnimatedNumber from "@/components/Global/AnimatedNumber";
 import { WidgetProps } from "@/components/Home/Widget";
@@ -13,134 +12,150 @@ import { useCurrentAccount } from "@/stores/account";
 import { useGradesStore } from "@/stores/grades";
 import { getPronoteAverage } from "@/utils/grades/getAverages";
 
-const GeneralAverageWidget = forwardRef(({
-  setLoading,
-  setHidden,
-  loading,
-}: WidgetProps, ref) => {
-  const theme = useTheme();
-  const { colors } = theme;
+const GeneralAverageWidget = forwardRef(
+  ({ setLoading, setHidden, loading }: WidgetProps, ref) => {
+    const theme = useTheme();
+    const { colors } = theme;
 
-  const account = useCurrentAccount((store) => store.account);
+    const account = useCurrentAccount((store) => store.account);
 
-  const grades = useGradesStore((store) => store.grades);
-  const averages = useGradesStore((store) => store.averages);
-  const defaultPeriod = useGradesStore((store) => store.defaultPeriod);
+    const grades = useGradesStore((store) => store.grades);
+    const averages = useGradesStore((store) => store.averages);
+    const defaultPeriod = useGradesStore((store) => store.defaultPeriod);
+    const currentPeriod = useGradesStore((store) => store.currentPeriod);
 
-  useImperativeHandle(ref, () => ({
-    handlePress: () => "Grades"
-  }));
+    useImperativeHandle(ref, () => ({
+      handlePress: () => "Grades",
+    }));
 
-  const average = useMemo(() => {
-    return !averages[defaultPeriod]?.overall.disabled
-      ? averages[defaultPeriod]?.overall.value
-      : getPronoteAverage(grades[defaultPeriod]);
-  }, [averages, grades, defaultPeriod]);
+    const average = useMemo(() => {
+      return !averages[defaultPeriod]?.overall.disabled
+        ? averages[defaultPeriod]?.overall.value
+        : getPronoteAverage(grades[defaultPeriod]);
+    }, [averages, grades, defaultPeriod]);
 
-  useEffect(() => {
-    void async function () {
-      if (!account?.instance) return;
-      setLoading(true);
+    useEffect(() => {
+      void async function () {
+        if (!account?.instance) return;
+        setLoading(true);
 
-      await updateGradesPeriodsInCache(account);
-      setLoading(false);
-    }();
-  }, [account?.instance]);
+        await updateGradesPeriodsInCache(account);
+        setLoading(false);
+      }();
+    }, [account?.instance]);
 
-  useEffect(() => {
-    void async function () {
-      if (!account?.instance || !defaultPeriod) return;
-      setLoading(true);
+    useEffect(() => {
+      void async function () {
+        if (!account?.instance || !defaultPeriod) return;
+        setLoading(true);
 
-      await updateGradesAndAveragesInCache(account, defaultPeriod);
-      setLoading(false);
-    }();
-  }, [defaultPeriod]);
+        await updateGradesAndAveragesInCache(account, defaultPeriod);
+        setLoading(false);
+      }();
+    }, [defaultPeriod]);
 
-  useEffect(() => {
-    setHidden(typeof average !== "number" || average < 0);
-  }, [average]);
+    useEffect(() => {
+      setHidden(typeof average !== "number" || average < 0);
+    }, [average]);
 
-  if (isNaN(average ?? 0)) {
-    setHidden(true);
-  }
+    if (isNaN(average ?? 0)) {
+      setHidden(true);
+    }
 
-  return (
-    <>
-      <View
-        style={{
-          justifyContent: "flex-start",
-          alignItems: "center",
-          flexDirection: "row",
-          width: "100%",
-          gap: 7,
-          opacity: 0.5,
-        }}
-      >
-        <PieChart size={20} color={colors.text} />
-        <Text
+    return (
+      <>
+        {/* Section Notes */}
+        <View
           style={{
-            color: colors.text,
-            fontFamily: "semibold",
-            fontSize: 16,
+            justifyContent: "flex-start",
+            alignItems: "center",
+            flexDirection: "row",
+            width: "100%",
+            gap: 7,
+            opacity: 0.5,
           }}
         >
-          Notes
-        </Text>
-      </View>
+          <PieChart size={20} color={colors.text} />
+          <Text
+            style={{
+              color: colors.text,
+              fontFamily: "semibold",
+              fontSize: 17,
+            }}
+          >
+            Mes Notes
+          </Text>
+        </View>
 
-      <Reanimated.View
-        style={{
-          alignItems: "flex-start",
-          flexDirection: "column",
-          width: "100%",
-          marginTop: "auto",
-          gap: 4,
-        }}
-        layout={LinearTransition}
-      >
+        {/* Texte de la Période Actuelle avec la période dynamique */}
         <Reanimated.Text
           style={{
-            color: colors.text + "50",
+            color: colors.text,
+            marginTop: 17,
             fontFamily: "medium",
-            fontSize: 16,
+            fontSize: 15,
+            marginVertical: 4,
+            opacity: 0.4,
           }}
           layout={LinearTransition}
         >
-          Moyenne générale
+          Période actuelle: {currentPeriod || "Indisponible"} {/* Utilise la période actuelle dynamique */}
         </Reanimated.Text>
 
+        {/* Section Moyenne Générale */}
         <Reanimated.View
           style={{
-            flexDirection: "row",
-            alignItems: "flex-end",
+            alignItems: "flex-start",
+            flexDirection: "column",
+            width: "100%",
+            marginTop: "auto",
             gap: 4,
           }}
+          layout={LinearTransition}
         >
-          <AnimatedNumber
-            value={average?.toFixed(2) ?? ""}
-            style={{
-              fontSize: 24,
-              lineHeight: 24,
-              fontFamily: "semibold",
-            }}
-            contentContainerStyle={{
-              paddingLeft: 6,
-            }}
-          />
-          <Text
+          <Reanimated.Text
             style={{
               color: colors.text + "50",
               fontFamily: "medium",
               fontSize: 16,
             }}
+            layout={LinearTransition}
           >
-            /20
-          </Text>
+            Moyenne générale
+          </Reanimated.Text>
+
+          <Reanimated.View
+            style={{
+              flexDirection: "row",
+              alignItems: "flex-end",
+              gap: 4,
+            }}
+          >
+            <AnimatedNumber
+              value={average?.toFixed(2) ?? ""}
+              style={{
+                fontSize: 24,
+                lineHeight: 24,
+                fontFamily: "semibold",
+              }}
+              contentContainerStyle={{
+                paddingLeft: 6,
+              }}
+            />
+            <Text
+              style={{
+                color: colors.text + "50",
+                fontFamily: "medium",
+                fontSize: 16,
+              }}
+            >
+              /20
+            </Text>
+          </Reanimated.View>
         </Reanimated.View>
-      </Reanimated.View>
-    </>
-  );
-});
+      </>
+    );
+  }
+);
 
 export default GeneralAverageWidget;

--- a/src/widgets/Components/GeneralAverage.tsx
+++ b/src/widgets/Components/GeneralAverage.tsx
@@ -72,6 +72,7 @@ const GeneralAverageWidget = forwardRef(
             width: "100%",
             gap: 7,
             opacity: 0.5,
+            marginBottom: 8, // Ajoute de l'espace entre Mes Notes et Période actuelle
           }}
         >
           <PieChart size={20} color={colors.text} />
@@ -90,7 +91,6 @@ const GeneralAverageWidget = forwardRef(
         <Reanimated.Text
           style={{
             color: colors.text,
-            marginTop: 17,
             fontFamily: "medium",
             fontSize: 15,
             marginVertical: 4,
@@ -98,7 +98,10 @@ const GeneralAverageWidget = forwardRef(
           }}
           layout={LinearTransition}
         >
-          Période actuelle: {currentPeriod || "Indisponible"} {/* Utilise la période actuelle dynamique */}
+          Période actuelle: {"\n"} {/* Saut de ligne avant la période */}
+          <Text style={{ fontWeight: "bold", }}>
+            {currentPeriod || "Indisponible"}
+          </Text>
         </Reanimated.Text>
 
         {/* Section Moyenne Générale */}

--- a/src/widgets/Components/GeneralAverage.tsx
+++ b/src/widgets/Components/GeneralAverage.tsx
@@ -1,4 +1,3 @@
-
 import { useTheme } from "@react-navigation/native";
 import { PieChart } from "lucide-react-native";
 import React, { forwardRef, useEffect, useImperativeHandle, useMemo } from "react";
@@ -130,6 +129,7 @@ const GeneralAverageWidget = forwardRef(
               alignItems: "flex-end",
               gap: 4,
             }}
+            layout={LinearTransition}
           >
             <AnimatedNumber
               value={average?.toFixed(2) ?? ""}


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

### Changelog

**Improving** the `GeneralAverageWidget` component by dynamically displaying the current period (e.g., "Trimester", "Semester") based on the data from Pronote. Key changes include:

- Dynamically fetched and displayed the "Current Period" under "Mes Notes" in the widget.
- Introduced a new `currentPeriod` state in `useGradesStore` to accurately reflect the current period set in Pronote.
- Optimized the fetching logic by ensuring `currentPeriod` is updated whenever grades or averages are updated.
- Ensured seamless integration without breaking existing functionalities or affecting performance.

These enhancements provide a more accurate and dynamic user experience by correctly reflecting the current grading period from Pronote.

<img src="https://github.com/user-attachments/assets/279be588-5537-46dc-a2e5-5a807a1eaba6" alt="Screenshot_2024-09-05-23-10-26-837_xyz getpapillon app-edit" width="300" />


(c.f. picture)

