### PR TITLE
fix: réparation du nom de matière personnalisé pour le modal et le widget

### DIFF
--- a/app/(modals)/course.tsx
+++ b/app/(modals)/course.tsx
@@ -17,6 +17,7 @@ import Icon from "@/ui/components/Icon";
 import LinearGradient from "react-native-linear-gradient";
 import Course from "@/ui/components/Course";
 import { getStatusText } from "../(tabs)/calendar";
+import { getSubjectName } from '@/utils/subjects/name';
 
 interface SubjectInfo {
   name: string;
@@ -96,7 +97,7 @@ export default function CourseModal() {
             <Reanimated.View>
               <Course
                 id={item.id}
-                name={item.subject}
+                name={getSubjectName(item.subject)}
                 teacher={item.teacher}
                 room={item.room}
                 color={subjectInfo.color}

--- a/app/(tabs)/index/index.tsx
+++ b/app/(tabs)/index/index.tsx
@@ -459,7 +459,7 @@ const IndexScreen = () => {
                   <Course
                     key={item.id}
                     id={item.id}
-                    name={item.subject}
+                    name={getSubjectName(item.subject)}
                     teacher={item.teacher}
                     room={item.room}
                     color={getSubjectColor(item.subject)}


### PR DESCRIPTION
![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous vous invitons à vérifier que vous avez bien respecté les règles de contribution. Sans cela, votre Pull Request ne pourra pas être examinée.

- [X] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [X] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [X] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [X] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [X] J’emploie un langage informel, clair et concis dans mes messages.
- [X] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [X] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Résumé des changements

Réparation du modal course qui n'affichaient pas le nom de matière personnalisé. ([049a495](https://github.com/Orafilynie/Papillon/commit/049a49566c48e3f1aa1f0e098e707bfd59d5568c))
Réparation du widget calendar qui n'affichaient pas le nom de matière personnalisé. ([7617f70](https://github.com/Orafilynie/Papillon/commit/7617f70818f9c39dd851c9c55f568bc3756dd4f0))
