### PR TITLE
fix: fixed the border radius being missing after the animation in the…

### DIFF
--- a/ui/components/NativeHeader.tsx
+++ b/ui/components/NativeHeader.tsx
@@ -272,7 +272,7 @@ const NativeHeaderHighlight = React.memo(function NativeHeaderHighlight({
 
   return (
     <LayoutAnimationConfig skipEntering>
-      <View style={viewStyle} {...props}>
+      <View style={[viewStyle, { borderRadius: light ? 0 : styles.highlight.borderRadius }]} {...props}>
         {typeof children === 'string' ? (
           <AnimatedNumber variant="navigation" style={{ color }}>
             {children}

--- a/ui/components/NativeHeader.tsx
+++ b/ui/components/NativeHeader.tsx
@@ -268,11 +268,11 @@ const NativeHeaderHighlight = React.memo(function NativeHeaderHighlight({
   const backgroundColor = light ? 'transparent' : color === DEFAULT_COLOR ? DEFAULT_BACKGROUND_COLOR : getBackgroundColor(color);
 
   // Pre-compute style array once
-  const viewStyle = style ? [styles.highlight, { backgroundColor }, style, light ? { padding: 0 } : {}] : [styles.highlight, { backgroundColor }, light ? { padding: 0 } : {}];
+  const viewStyle = style ? [styles.highlight, { backgroundColor }, style, light ? { padding: 0 } : {}] : [styles.highlight, { backgroundColor }, { borderRadius: light ? 0 : styles.highlight.borderRadius }, light ? { padding: 0 } : {}];
 
   return (
     <LayoutAnimationConfig skipEntering>
-      <View style={[viewStyle, { borderRadius: light ? 0 : styles.highlight.borderRadius }]} {...props}>
+      <View style={viewStyle} {...props}>
         {typeof children === 'string' ? (
           <AnimatedNumber variant="navigation" style={{ color }}>
             {children}


### PR DESCRIPTION
… tasks

![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous vous invitons à vérifier que vous avez bien respecté les règles de contribution. Sans cela, votre Pull Request ne pourra pas être examinée.

- [X] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [ ] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [X] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [ ] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [ ] J’emploie un langage informel, clair et concis dans mes messages.
- [X] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [ ] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Résumé des changements

> [!NOTE]
> Une description détaillée des changements apportés dans cette Pull Request permet un traitement plus efficace et rapide.

- modification du NativeHeader pour forcer le border radius meme apres l'animation
# Capture(s) d'écran

> [!NOTE]
> Uniquement si vos changements concernent l'interface utilisateur, veuillez inclure des captures d'écran pour illustrer vos modifications.
[video](https://cdn.discordapp.com/attachments/1386792059372961846/1424381585033003008/screen-20251005-1501422.mp4?ex=68e3be39&is=68e26cb9&hm=52a83cb7c1bf5bad3ea01e1c9555dcbc582a1f1cd22610fb33d1f5d366372329&)

# Informations supplémentaires
> [!NOTE]
> Numéro des issues concernées par cette Pull Request, détail sur le fonctionnement ou les choix techniques effectués, ainsi que toute autre information pertinente.
