### PR TITLE
fix(UI): correct period name display ("Trimestre 1" instead of "er Trimestre 1")

### DIFF
--- a/utils/services/periods.ts
+++ b/utils/services/periods.ts
@@ -2,9 +2,11 @@ import { t } from "i18next";
 
 
 export const getPeriodName = (name: string) => {
-  // return only name
-  let digits = name.replace(/[^0-9]/g, '').trim();
-  let newName = name.replace(digits, '').trim();
+  // Clean up the string: remove digits and trim
+  let newName = name.replace(/[0-9]/g, '').trim();
+
+  // Remove common prefixes that might be leftover (like "er" from "1er")
+  newName = newName.replace(/^(er|ème|eme)\s*/i, '').trim();
 
   switch (newName.toLowerCase()) {
     case "trimestre":


### PR DESCRIPTION
Corrige un problème d'affichage notamment dans l'onglet note où le Trimestre s'affichait "er Trimestre 1" à la place de "Trimestre 1".
Ajout d'un filtre dans la function getPeriodName pour retire les préfixes "er", "ème" ou "eme"

Fixes: #388 

![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [x] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [ ] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [x] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [x] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [x] J’emploie un langage informel, clair et concis dans mes messages.
- [x] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [ ] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Résumé des changements

> [!NOTE]
> Une description détaillée des changements apportés dans cette Pull Request permet un traitement plus efficace et rapide.

# Capture(s) d'écran

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-13 at 21 41 15" src="https://github.com/user-attachments/assets/8efa31c5-18bc-4e40-80c2-bcc8288b64ea" />


> [!NOTE]
> Si tes changements concernent l'interface utilisateur, inclue des captures d'écran pour illustrer tes modifications.

# Informations supplémentaires
> [!NOTE]
> Numéro des issues concernées par cette Pull Request, détail sur le fonctionnement ou les choix techniques effectués, ainsi que toute autre information pertinente.
