### PR TITLE
fix: unavailable android platform color (#476)

### DIFF
--- a/app/(tabs)/tasks/index.tsx
+++ b/app/(tabs)/tasks/index.tsx
@@ -9,7 +9,6 @@ import {
   KeyboardAvoidingView,
   Modal,
   Platform,
-  PlatformColor,
   Pressable,
   RefreshControl,
   Text,
@@ -468,7 +467,7 @@ export default function TabOneScreen() {
                 effect="regular"
               >
                 <Pressable onPress={() => setShowSearch(false)} hitSlop={32}>
-                  <Papicons name={"cross"} color={PlatformColor('labelColor')} size={24} opacity={0.5} />
+                  <Papicons name={"cross"} color={colors.text} size={24} opacity={0.5} />
                 </Pressable>
               </LiquidGlassView>
             </LiquidGlassContainerView>


### PR DESCRIPTION
![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [x] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [ ] Cette Pull Request n'est pas faite essentiellement avec de l'IA.
- [ ] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [x] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [ ] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [x] J’emploie un langage informel, clair et concis dans mes messages.
- [x] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [ ] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Résumé des changements

- Remplacé la couleur du Papicons `cross` de `PlatformColor('labelColor')` pour `colors.text`. La PlatformColor pour `labelColor` n'existe pas sur Android, ce qui causait un crash.
- Enlevé l'import de `PlatformColor` de `react-native`.

# Informations supplémentaires

Issues concernées : #476 