### PR TITLE
fix: bug de l'an 2026

### DIFF
--- a/app/(tabs)/calendar/hooks/useTimetableData.ts
+++ b/app/(tabs)/calendar/hooks/useTimetableData.ts
@@ -5,8 +5,8 @@ import { getManager, subscribeManagerUpdate } from "@/services/shared";
 import { useAccountStore } from '@/stores/account';
 import { log, warn } from "@/utils/logger/logger";
 
-export function useTimetableData(weekNumber: number, currentDate: Date) {
-  const safeDate = currentDate || new Date();
+export function useTimetableData(weekNumber: number, currentDate: Date = new Date()) {
+  const safeDate = currentDate;
   const [isLoading, setIsLoading] = useState(false);
   const [refresh, setRefresh] = useState(0);
   const [manualRefreshing, setManualRefreshing] = useState(false);

--- a/app/(tabs)/calendar/hooks/useTimetableData.ts
+++ b/app/(tabs)/calendar/hooks/useTimetableData.ts
@@ -89,7 +89,7 @@ export function useTimetableData(weekNumber: number, currentDate: Date) {
 
   useEffect(() => {
     fetchWeeklyTimetable(weekNumber);
-  }, [weekNumber]);
+  }, [weekNumber, fetchWeeklyTimetable]);
 
   useEffect(() => {
     const unsubscribe = subscribeManagerUpdate((updatedManager) => {
@@ -98,7 +98,7 @@ export function useTimetableData(weekNumber: number, currentDate: Date) {
       }
     });
     return () => unsubscribe();
-  }, [weekNumber]);
+  }, [weekNumber, fetchWeeklyTimetable]);
 
   useEffect(() => {
     return () => {

--- a/app/(tabs)/calendar/hooks/useTimetableData.ts
+++ b/app/(tabs)/calendar/hooks/useTimetableData.ts
@@ -13,7 +13,8 @@ export function useTimetableData(weekNumber: number, currentDate: Date) {
   const [fetchedWeeks, setFetchedWeeks] = useState<string[]>([]);
   const fetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  let manager: unknown;
+  let manager: ReturnType<typeof getManager> | null;
+
   try {
     manager = getManager();
   } catch (error) {

--- a/app/(tabs)/calendar/index.tsx
+++ b/app/(tabs)/calendar/index.tsx
@@ -35,7 +35,7 @@ export default function TabOneScreen() {
     manualRefreshing,
     handleRefresh,
     isLoading
-  } = useTimetableData(weekNumber);
+  } = useTimetableData(weekNumber, date);
 
   const renderDay = useCallback(({ index }: { index: number }) => {
     const dayDate = getDateFromIndex(index);

--- a/app/(tabs)/index/hooks/useHomeData.ts
+++ b/app/(tabs)/index/hooks/useHomeData.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect } from 'react';
-import { getManager, initializeAccountManager } from "@/services/shared";
-import { useAlert } from '@/ui/components/AlertProvider';
-import { log, warn } from '@/utils/logger/logger';
+
 import { getWeekNumberFromDate } from '@/database/useHomework';
+import { getManager, initializeAccountManager } from "@/services/shared";
 import { Grade, Period } from '@/services/shared/grade';
-import { getCurrentPeriod } from '@/utils/grades/helper/period';
 import { useSettingsStore } from '@/stores/settings';
+import { useAlert } from '@/ui/components/AlertProvider';
+import { getCurrentPeriod } from '@/utils/grades/helper/period';
+import { log, warn } from '@/utils/logger/logger';
 
 export const useHomeData = () => {
   const alert = useAlert();
@@ -15,7 +16,7 @@ export const useHomeData = () => {
     const manager = getManager();
     const date = new Date();
     const weekNumber = getWeekNumberFromDate(date);
-    await manager.getWeeklyTimetable(weekNumber);
+    await manager.getWeeklyTimetable(weekNumber, date);
   }, []);
 
   const fetchGrades = useCallback(async () => {
@@ -37,12 +38,12 @@ export const useHomeData = () => {
     const currentPeriod = getCurrentPeriod(validPeriods);
 
     if (currentPeriod) {
-        const periodGrades = await manager.getGradesForPeriod(currentPeriod, currentPeriod.createdByAccount);
-        periodGrades.subjects.forEach(subject => {
-            subject.grades.forEach(grade => {
-                grades.push(grade);
-            });
+      const periodGrades = await manager.getGradesForPeriod(currentPeriod, currentPeriod.createdByAccount);
+      periodGrades.subjects.forEach(subject => {
+        subject.grades.forEach(grade => {
+          grades.push(grade);
         });
+      });
     }
   }, []);
 

--- a/app/(tabs)/tasks/components/TasksHeader.tsx
+++ b/app/(tabs)/tasks/components/TasksHeader.tsx
@@ -55,7 +55,7 @@ const TasksHeader: React.FC<TasksHeaderProps> = ({
         <TabHeaderTitle
           leading={t('Tasks_Week')}
           subtitle={selectedWeek === defaultWeek ? t('Tasks_ThisWeek') : undefined}
-          number={getWeekNumberFromDate(getDateRangeOfWeek(selectedWeek).start).toString()}
+          number={getWeekNumberFromDate(getDateRangeOfWeek(selectedWeek, new Date().getFullYear()).start).toString()}
           color='#C54CB3'
           onPress={onToggleWeekPicker}
           height={56}

--- a/app/(tabs)/tasks/components/TasksHeader.tsx
+++ b/app/(tabs)/tasks/components/TasksHeader.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react';
-import { Platform } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import { t } from 'i18next';
+import React, { useMemo } from 'react';
+import { Platform } from 'react-native';
 
+import { getDateRangeOfWeek, getWeekNumberFromDate } from '@/database/useHomework';
 import ChipButton from '@/ui/components/ChipButton';
 import Search from '@/ui/components/Search';
 import TabHeader from '@/ui/components/TabHeader';
@@ -53,8 +54,8 @@ const TasksHeader: React.FC<TasksHeaderProps> = ({
       title={
         <TabHeaderTitle
           leading={t('Tasks_Week')}
-          subtitle={selectedWeek == defaultWeek ? t('Tasks_ThisWeek') : undefined}
-          number={selectedWeek.toString()}
+          subtitle={selectedWeek === defaultWeek ? t('Tasks_ThisWeek') : undefined}
+          number={getWeekNumberFromDate(getDateRangeOfWeek(selectedWeek).start).toString()}
           color='#C54CB3'
           onPress={onToggleWeekPicker}
           height={56}

--- a/app/(tabs)/tasks/components/WeekPicker.tsx
+++ b/app/(tabs)/tasks/components/WeekPicker.tsx
@@ -1,10 +1,11 @@
+import { useTheme } from '@react-navigation/native';
+import { BlurView } from 'expo-blur';
 import React, { useCallback, useRef } from 'react';
 import { FlatList, Pressable, Text, View } from 'react-native';
 import Reanimated from 'react-native-reanimated';
-import { BlurView } from 'expo-blur';
-import { useTheme } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { getDateRangeOfWeek, getWeekNumberFromDate } from '@/database/useHomework';
 import { runsIOS26 } from '@/ui/utils/IsLiquidGlass';
 import { PapillonAppearIn, PapillonAppearOut } from '@/ui/utils/Transition';
 
@@ -33,7 +34,7 @@ const WeekPicker: React.FC<WeekPickerProps> = ({ selectedWeek, onSelectWeek, onC
     const contentOffsetX = event.nativeEvent.contentOffset.x;
     const itemWidth = 60;
     const index = Math.round(contentOffsetX / itemWidth);
-    if (index < 0 || index >= 56) { return; }
+    if (index < 0 || index >= 300) { return; }
     requestAnimationFrame(() => {
       onSelectWeek(index);
     });
@@ -80,7 +81,7 @@ const WeekPicker: React.FC<WeekPickerProps> = ({ selectedWeek, onSelectWeek, onC
           onLayout={() => {
             layoutPicker();
           }}
-          data={Array.from({ length: 56 }, (_, i) => i)}
+          data={Array.from({ length: 300 }, (_, i) => i)}
           initialScrollIndex={selectedWeek}
           getItemLayout={(data, index) => (
             { length: 60, offset: 60 * index, index }
@@ -137,7 +138,7 @@ const WeekPicker: React.FC<WeekPickerProps> = ({ selectedWeek, onSelectWeek, onC
                   fontFamily: item === selectedWeek ? "bold" : "medium",
                 }}
               >
-                {item}
+                {getWeekNumberFromDate(getDateRangeOfWeek(item).start)}
               </Text>
             </Pressable>
           )}

--- a/app/(tabs)/tasks/components/WeekPicker.tsx
+++ b/app/(tabs)/tasks/components/WeekPicker.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@react-navigation/native';
 import { BlurView } from 'expo-blur';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { FlatList, Pressable, Text, View } from 'react-native';
 import Reanimated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -30,11 +30,17 @@ const WeekPicker: React.FC<WeekPickerProps> = ({ selectedWeek, onSelectWeek, onC
     }
   }, [selectedWeek]);
 
+  const [weekLimit, setWeekLimit] = useState(60);
+
+  const loadMoreWeeks = useCallback(() => {
+    setWeekLimit((prev) => prev + 26);
+  }, []);
+
   const handleWeekScroll = useCallback((event: { nativeEvent: { contentOffset: { x: number } } }) => {
     const contentOffsetX = event.nativeEvent.contentOffset.x;
     const itemWidth = 60;
     const index = Math.round(contentOffsetX / itemWidth);
-    if (index < 0 || index >= 300) { return; }
+    if (index < 0 || index >= weekLimit) { return; }
     requestAnimationFrame(() => {
       onSelectWeek(index);
     });
@@ -81,7 +87,10 @@ const WeekPicker: React.FC<WeekPickerProps> = ({ selectedWeek, onSelectWeek, onC
           onLayout={() => {
             layoutPicker();
           }}
-          data={Array.from({ length: 300 }, (_, i) => i)}
+          data={Array.from({ length: weekLimit }, (_, i) => i)}
+          onEndReached={loadMoreWeeks}
+          onEndReachedThreshold={2}
+          windowSize={5}
           initialScrollIndex={selectedWeek}
           getItemLayout={(data, index) => (
             { length: 60, offset: 60 * index, index }
@@ -138,7 +147,7 @@ const WeekPicker: React.FC<WeekPickerProps> = ({ selectedWeek, onSelectWeek, onC
                   fontFamily: item === selectedWeek ? "bold" : "medium",
                 }}
               >
-                {getWeekNumberFromDate(getDateRangeOfWeek(item).start)}
+                {getWeekNumberFromDate(getDateRangeOfWeek(item, new Date().getFullYear()).start)}
               </Text>
             </Pressable>
           )}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,12 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
+
 import 'react-native-reanimated';
 import "@/utils/i18n";
+
 import { Buffer } from 'buffer';
 import React from 'react';
 
-import FakeSplash from '@/components/FakeSplash';
 import { AppProviders } from '@/components/AppProviders';
+import FakeSplash from '@/components/FakeSplash';
 import { RootNavigator } from '@/components/RootNavigator';
 import { useAppInitialization } from '@/hooks/useAppInitialization';
 

--- a/services/appscho/index.ts
+++ b/services/appscho/index.ts
@@ -31,7 +31,7 @@ export class Appscho implements SchoolServicePlugin {
     }
   }
 
-  async getWeeklyTimetable(weekNumber: number, forceRefresh?: boolean): Promise<CourseDay[]> {
+  async getWeeklyTimetable(weekNumber: number, date: Date, forceRefresh?: boolean): Promise<CourseDay[]> {
     if (this.session) {
       const instanceId = String(this.authData.additionals?.["instanceId"]);
       return fetchAppschoTimetable(this.session, this.accountId, weekNumber, instanceId, forceRefresh);

--- a/services/ecoledirecte/index.ts
+++ b/services/ecoledirecte/index.ts
@@ -91,7 +91,7 @@ export class EcoleDirecte implements SchoolServicePlugin {
     error("Session or account is not valid", "EcoleDirecte.getAttendanceForPeriod");
   }
 
-  async getWeeklyTimetable(weekNumber: number): Promise<CourseDay[]> {
+  async getWeeklyTimetable(weekNumber: number, date: Date): Promise<CourseDay[]> {
     if (this.session && this.account) {
       return fetchEDTimetable(this.session, this.account, this.accountId, weekNumber)
     }

--- a/services/multi/index.ts
+++ b/services/multi/index.ts
@@ -39,7 +39,7 @@ export class Multi implements SchoolServicePlugin {
     error("Session is not valid", "Multi.getNews");
   }
 
-  async getWeeklyTimetable(weekNumber: number): Promise<CourseDay[]> {
+  async getWeeklyTimetable(weekNumber: number, date: Date): Promise<CourseDay[]> {
     if (this.session) {
       return fetchMultiTimetable(this.session, this.accountId, weekNumber);
     }

--- a/services/pronote/index.ts
+++ b/services/pronote/index.ts
@@ -140,11 +140,11 @@ export class Pronote implements SchoolServicePlugin {
     error("Session is not valid", "Pronote.getWeeklyCanteenMenu");
   }
 
-  async getWeeklyTimetable(weekNumber: number): Promise<CourseDay[]> {
+  async getWeeklyTimetable(weekNumber: number, date: Date): Promise<CourseDay[]> {
     await this.checkTokenValidty()
 
     if (this.session) {
-      return fetchPronoteWeekTimetable(this.session, this.accountId, weekNumber);
+      return fetchPronoteWeekTimetable(this.session, this.accountId, weekNumber, date);
     }
 
     error("Session is not valid", "Pronote.getWeeklyTimetable");

--- a/services/pronote/timetable.ts
+++ b/services/pronote/timetable.ts
@@ -16,14 +16,14 @@ import { error } from "@/utils/logger/logger";
 export async function fetchPronoteWeekTimetable(
   session: SessionHandle,
   accountId: string,
-  weekNumberRaw: number
+  weekNumberRaw: number,
+  date: Date
 ): Promise<CourseDay[]> {
   if (!session) {
     error("Session is undefined", "fetchPronoteTimetable");
   }
 
-  const { start } = getDateRangeOfWeek(weekNumberRaw)
-  const weekNumber = translateToWeekNumber(start, session.instance.firstMonday);
+  const weekNumber = translateToWeekNumber(date, session.instance.firstMonday);
   const timetable = await timetableFromWeek(session, weekNumber);
 
   parseTimetable(session, timetable, {

--- a/services/shared/index.ts
+++ b/services/shared/index.ts
@@ -316,16 +316,16 @@ export class AccountManager {
     );
   }
 
-  async getWeeklyTimetable(weekNumber: number): Promise<CourseDay[]> {
+  async getWeeklyTimetable(weekNumber: number, date: Date): Promise<CourseDay[]> {
     return await this.fetchData(
       Capabilities.TIMETABLE,
       async client =>
         client.getWeeklyTimetable
-          ? await client.getWeeklyTimetable(weekNumber)
+          ? await client.getWeeklyTimetable(weekNumber, date)
           : [],
       {
         multiple: true,
-        fallback: async () => getCoursesFromCache(weekNumber),
+        fallback: async () => getCoursesFromCache([weekNumber], date.getFullYear()),
         saveToCache: async (data: CourseDay[]) => {
           addCourseDayToDatabase(data);
         },

--- a/services/shared/types.ts
+++ b/services/shared/types.ts
@@ -77,7 +77,7 @@ export interface SchoolServicePlugin {
   getChatMessages?: (chat: Chat) => Promise<Message[]>;
   getRecipientsAvailableForNewChat?: () => Promise<Recipient[]>;
   getCourseResources?: (course: Course) => Promise<CourseResource[]>;
-  getWeeklyTimetable?: (weekNumber: number) => Promise<CourseDay[]>;
+  getWeeklyTimetable?: (weekNumber: number, date: Date) => Promise<CourseDay[]>;
   sendMessageInChat?: (chat: Chat, content: string) => Promise<void>;
   setNewsAsAcknowledged?: (news: News) => Promise<News>;
   setHomeworkCompletion?: (

--- a/services/skolengo/index.ts
+++ b/services/skolengo/index.ts
@@ -107,7 +107,7 @@ export class Skolengo implements SchoolServicePlugin {
     error ("Session is not valid", "Skolengo.getAttendanceForPeriod")
   }
 
-  async getWeeklyTimetable(weekNumber: number): Promise<CourseDay[]> {
+  async getWeeklyTimetable(weekNumber: number, date: Date): Promise<CourseDay[]> {
     if (this.session) {
       return fetchSkolengoTimetable(this.session, this.accountId, weekNumber)
     }


### PR DESCRIPTION
Correction du bug de l'an 2026 🤡 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * L'emploi du temps tient compte d'une date explicite, se recharge automatiquement lors de changement de date/année et segmente le cache par année.
  * Filtrage renforcé pour n'afficher uniquement les cours pertinents (y compris imports iCal).
  * Retour d'état de chargement et option de rafraîchissement exposés.

* **Nouveautés**
  * Le sélecteur de semaines charge dynamiquement davantage de semaines et affiche les numéros de semaine calculés.

* **Corrections**
  * Rendu du numéro de semaine dans l'en-tête des tâches rendu plus fiable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->