### PR TITLE
fix(turboself): add fallback balance to prevent card UI block

### DIFF
--- a/services/turboself/index.ts
+++ b/services/turboself/index.ts
@@ -48,13 +48,30 @@ export class TurboSelf implements SchoolServicePlugin {
     return CanteenKind.FORFAIT;
   }
 
-  async getCanteenBalances(): Promise<Balance[]> {
-    if (this.session) {
-      return fetchTurboSelfBalance(this.session, this.accountId)
-    }
-
-    error("Session is not valid", "TurboSelf.getCanteenBalances");
-  }
+	async getCanteenBalances(): Promise<Balance[]> {
+	    const fallbackBalance: Balance[] = [{
+	      amount: 0, 
+	      currency: "€",
+	      label: "Solde TurboSelf",
+	      createdByAccount: this.accountId,
+	      lunchRemaining: 0,
+	      lunchPrice: 0
+	    }];
+	
+	    if (!this.session) {
+	      error("Session is not valid", "TurboSelf.getCanteenBalances");
+	      return fallbackBalance;
+	    }
+	
+	    try {
+	      const balances = await fetchTurboSelfBalance(this.session, this.accountId);
+	      if (balances && balances.length > 0) return balances;
+	    } catch (e) {
+			error("Failed to fetch balances", "TurboSelf.getCanteenBalances", e);
+		}
+	    
+	    return fallbackBalance;
+	  }
 
   async getCanteenTransactionsHistory(): Promise<CanteenHistoryItem[]> {
     if (this.session) {

--- a/services/turboself/index.ts
+++ b/services/turboself/index.ts
@@ -48,30 +48,30 @@ export class TurboSelf implements SchoolServicePlugin {
     return CanteenKind.FORFAIT;
   }
 
-	async getCanteenBalances(): Promise<Balance[]> {
-	    const fallbackBalance: Balance[] = [{
-	      amount: 0, 
-	      currency: "€",
-	      label: "Solde TurboSelf",
-	      createdByAccount: this.accountId,
-	      lunchRemaining: 0,
-	      lunchPrice: 0
-	    }];
-	
-	    if (!this.session) {
-	      error("Session is not valid", "TurboSelf.getCanteenBalances");
-	      return fallbackBalance;
-	    }
-	
-	    try {
-	      const balances = await fetchTurboSelfBalance(this.session, this.accountId);
-	      if (balances && balances.length > 0) return balances;
-	    } catch (e) {
-			error("Failed to fetch balances", "TurboSelf.getCanteenBalances", e);
-		}
-	    
-	    return fallbackBalance;
-	  }
+  async getCanteenBalances(): Promise<Balance[]> {
+      const fallbackBalance: Balance[] = [{
+        amount: 0, 
+        currency: this.session?.establishment?.currencySymbol ?? "€",
+        label: "Solde : (chargement...) - données temporaires",
+        createdByAccount: this.accountId,
+        lunchRemaining: 0,
+        lunchPrice: 0
+      }];
+  
+      if (!this.session) {
+        error("Session is not valid", "TurboSelf.getCanteenBalances");
+        return fallbackBalance;
+      }
+  
+      try {
+        const balances = await fetchTurboSelfBalance(this.session, this.accountId);
+        if (balances && balances.length > 0) return balances; // On évite de retourner un tableau vide pour garder la carte visible grâce à un fallback
+      } catch (e) {
+      error("Failed to fetch balances", "TurboSelf.getCanteenBalances", e);
+    }
+      
+      return fallbackBalance;
+    }
 
   async getCanteenTransactionsHistory(): Promise<CanteenHistoryItem[]> {
     if (this.session) {


### PR DESCRIPTION
![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [x] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [x] Cette Pull Request n'est pas faite essentiellement avec de l'IA.
- [x] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [x] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [ ] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [x] J’emploie un langage informel, clair et concis dans mes messages.
- [x] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [x] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Résumé des changements

Correction d'un bug qui faisait que, dans certains cas, la carte turboself n'apparaissait juste pas, le login fonctionnait mais aucune fonction n'était appelée ensuite, bloquant l'affichage de la carte.
Pour corriger j'ai : 
- Ajouté "fallbackBalance", un solde de secours en cas d'échec le temps que les infos du compte arrivent à Papillon et se mettent à jour.

# Capture(s) d'écran

<img width="480" height="270" alt="Capture d’écran du 2025-12-23 19-28-21" src="https://github.com/user-attachments/assets/d0195e89-184a-4a96-bf1f-7e120bb30590" />
<img width="518" height="370" alt="Capture d’écran du 2025-12-23 19-28-49" src="https://github.com/user-attachments/assets/ca1f7ff2-3898-4927-b8e4-c7445f83b8e4" />


# Infos en plus : 

J'ai testé les modifs sur Android, n'ayant qu'un seul type de compte, il serait cool que Raphaël ou Maël puissent tester avec les leurs (je crois ils en ont un) pour confirmer que le fallback ne masque pas d'autres soucis de données. (my bad pour la première pr que j'ai close j'avais fait de la dé)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correctifs de bogues**
  * Meilleure stabilité du service de soldes : en cas d’erreur ou d’absence de session, une valeur de solde par défaut est désormais retournée pour éviter les interruptions.
  * Gestion plus robuste des cas vides : si la récupération des soldes échoue ou renvoie un tableau vide, l’application utilise une solution de repli pour préserver l’expérience utilisateur.
* **Améliorations**
  * Journalisation des erreurs renforcée pour faciliter le diagnostic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->