### PR TITLE
Fix: Réparation du service AppScho

### DIFF
--- a/services/appscho/index.ts
+++ b/services/appscho/index.ts
@@ -2,24 +2,75 @@ import { Capabilities, SchoolServicePlugin } from "@/services/shared/types";
 import { Auth, Services } from "@/stores/account/types";
 import { User } from "appscho";
 import { refreshAppSchoAccount } from "./refresh";
-import { error } from "@/utils/logger/logger";
+import { error, log } from "@/utils/logger/logger";
 import { CourseDay } from "@/services/shared/timetable";
 import { fetchAppschoTimetable } from "@/services/appscho/timetable";
 import { News } from "@/services/shared/news";
 import { fetchAppschoNews } from "@/services/appscho/news";
+import { useAccountStore } from "@/stores/account";
 
 export class Appscho implements SchoolServicePlugin {
   displayName = "AppScho";
   service = Services.APPSCHO;
-  capabilities: Capabilities[] = [Capabilities.REFRESH, Capabilities.TIMETABLE, Capabilities.NEWS];
+  capabilities: Capabilities[] = [Capabilities.TIMETABLE, Capabilities.NEWS];
   session: User | undefined;
   authData: Auth = {};
 
-  constructor(public accountId: string) {}
+  constructor(public accountId: string) {
+    const account = useAccountStore.getState().accounts.find(a => a.id === accountId);
+    const service = account?.services.find(s => s.serviceId === Services.APPSCHO);
+    
+    if (service?.auth) {
+      this.authData = service.auth;
+    }
+  }
+
+  private async requestWrapper<T>(requestFn: (session: User) => Promise<T>): Promise<T> {
+    try {
+      if (!this.session) {
+        await this.refreshAccount(this.authData);
+      }
+
+      const result = await requestFn(this.session!);
+
+      if (result && (result as any).state === "unauthorized") {
+        throw new Error("AppScho: Unauthorized State");
+      }
+
+      return result;
+    } catch (err: any) {
+      const errorMessage = String(err.message || "");
+      const isUnauthorized = 
+        errorMessage.includes("401") || 
+        errorMessage.includes("Unauthorized") || 
+        err?.state === "unauthorized";
+
+      if (isUnauthorized) {     
+        try {
+          await this.refreshAccount(this.authData);
+          
+          const retryResult = await requestFn(this.session!);
+
+          if (retryResult && (retryResult as any).state === "unauthorized") {
+            throw new Error("Persistent Unauthorized State");
+          }
+
+          return retryResult;
+        } catch (refreshErr) {
+          error(`[Appscho] Failed to refresh the unauthorized state: ${refreshErr}`, "Appscho.requestWrapper");
+          throw refreshErr;
+        }
+      }
+
+      throw err;
+    }
+  }
 
   async refreshAccount(credentials: Auth): Promise<Appscho> {
     try {
-      const refresh = await refreshAppSchoAccount(this.accountId, credentials);
+      const credsToUse = credentials?.additionals?.instanceId ? credentials : this.authData;
+      
+      const refresh = await refreshAppSchoAccount(this.accountId, credsToUse);
       
       this.authData = refresh.auth;
       this.session = refresh.session;
@@ -32,21 +83,16 @@ export class Appscho implements SchoolServicePlugin {
   }
 
   async getWeeklyTimetable(weekNumber: number, date: Date, forceRefresh?: boolean): Promise<CourseDay[]> {
-    if (this.session) {
+    return this.requestWrapper(async (currentSession) => {
       const instanceId = String(this.authData.additionals?.["instanceId"]);
-      return fetchAppschoTimetable(this.session, this.accountId, weekNumber, instanceId, forceRefresh);
-    }
-
-    error("Session is not valid", "Appscho.getWeeklyTimetable");
+      return fetchAppschoTimetable(currentSession, this.accountId, weekNumber, instanceId, forceRefresh);
+    });
   }
 
   async getNews(): Promise<News[]> {
-
-    if (this.session) {
+    return this.requestWrapper(async (currentSession) => {
       const instanceId = String(this.authData.additionals?.["instanceId"]);
-      return fetchAppschoNews(this.session, this.accountId, instanceId);
-    }
-
-    error("Session is not valid", "Appscho.getNews");
+      return fetchAppschoNews(currentSession, this.accountId, instanceId);
+    });
   }
 }


### PR DESCRIPTION
![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [X] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [X] Cette Pull Request n'est pas faite essentiellement avec de l'IA.
- [X] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [X] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [X] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [X] J’emploie un langage informel, clair et concis dans mes messages.
- [X] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [X] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Résumé des changements

Utilisation d'un refresh manuel via la lecture du state des réponses API pour éviter des refresh frénétiques du service pouvant causer un token desync pour le refresh, entrainent une perte permanenta du token.

Réparation de l’emploi n'affichant pas les cours du a un fuseau horaire hard codé.


**Instance UPJV**
Une future PR sera ouverte pour la mise a jour de la dépendance AppScho.js une fois les réparations menées dans celle-ci approuvées pour le fonctionnement de cette instance.

# Capture(s) d'écran

> [!NOTE]
> Si tes changements concernent l'interface utilisateur, inclue des captures d'écran pour illustrer tes modifications.

# Informations supplémentaires
> [!NOTE]
> Numéro des issues concernées par cette Pull Request, détail sur le fonctionnement ou les choix techniques effectués, ainsi que toute autre information pertinente.
