### PR TITLE
fix(android): Use native surface color for header background

### DIFF
--- a/components/AndroidHeaderBackground.tsx
+++ b/components/AndroidHeaderBackground.tsx
@@ -1,11 +1,9 @@
-import { useTheme } from "@react-navigation/native";
 import { Platform, PlatformColor, View } from "react-native";
 
 export default function AndroidHeaderBackground() {
   if(Platform.OS !== "android") return null;
-  const theme = useTheme();
   return (
-    <View style={{ flex: 1, backgroundColor: theme.colors.background, elevation: 4 }} />
+    <View style={{ flex: 1, backgroundColor: PlatformColor("?attr/colorSurface"), elevation: 4 }} />
   )
 }
 


### PR DESCRIPTION
## Summary

On recent Android versions, native components may use Material You dynamic colors, leading to visual inconsistencies with the React Native theme. This change updates the Android header to use the native `colorSurface` via `PlatformColor`, ensuring it matches the system theme and other native elements. This addresses the issue of incorrect or 'ugly' component colors on Android.

## Changes

- **components/AndroidHeaderBackground.tsx**: Replaced the hardcoded theme background color with `PlatformColor('?attr/colorSurface')`. This ensures the header background on Android uses the appropriate color from the native theme, fixing inconsistencies with Material You and other native components.

## Related Issue

Closes #722

