### PR TITLE
fix: empty state centering in timetable

### DIFF
--- a/app/(tabs)/calendar/components/CalendarDay.tsx
+++ b/app/(tabs)/calendar/components/CalendarDay.tsx
@@ -107,6 +107,8 @@ export const CalendarDay = React.memo(({ dayDate, courses, isRefreshing, onRefre
     return result;
   }, [dayEvents]);
 
+  const isEmpty = enrichedEvents.length === 0;
+
   return (
     <View style={{ width: Dimensions.get("window").width, flex: 1 }}>
       <FlatList
@@ -119,6 +121,7 @@ export const CalendarDay = React.memo(({ dayDate, courses, isRefreshing, onRefre
           gap: 4,
           paddingTop: headerHeight + 6,
           paddingBottom: tabBarHeight + 6,
+          ...(isEmpty ? { alignItems: "center" } : {}),
         }}
         refreshControl={
           <RefreshControl


### PR DESCRIPTION
![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [x] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [x] Cette Pull Request n'est pas faite essentiellement avec de l'IA.
- [x] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [x] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [x] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [x] J’emploie un langage informel, clair et concis dans mes messages.
- [x] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [x] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Résumé des changements
L'empty state de la timetable est maintenant centré horizontalement

# Capture(s) d'écran
<img width="646" height="405" alt="image" src="https://github.com/user-attachments/assets/df94c014-39d4-4837-9c4a-edae39ac420a" />
