### PR TITLE
fix: Use router.push instead of router.replace

### DIFF
--- a/app/(settings)/accounts.tsx
+++ b/app/(settings)/accounts.tsx
@@ -138,7 +138,7 @@ export default function AccountsView() {
         ))}
         <List.Item
           onPress={() =>
-            router.replace({
+            router.push({
               pathname: "/(onboarding)/ageSelection",
               params: { action: "addService" },
             })


### PR DESCRIPTION
fix le bug qui fait que quand tu essaie d'ajouter un nouveau compte depuis les paramètres comptes liés et que tu cliques sur le bouton retour arrière ça te redirige vers la page d'accueil plutôt que à l'endroit des paramètres ou on était avant

![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [x] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [x] Cette Pull Request n'est pas faite essentiellement avec de l'IA.
- [x] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [x] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [x] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [x] J’emploie un langage informel, clair et concis dans mes messages.
- [x] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [x] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.
