### PR TITLE
fix: Add SheetModal and refactor modals & ED 2FA UI

### DIFF
--- a/app/(onboarding)/services/ed/credentials.tsx
+++ b/app/(onboarding)/services/ed/credentials.tsx
@@ -1,4 +1,4 @@
-
+import { Papicons } from "@getpapillon/papicons";
 import { Client, DoubleAuthQuestions, DoubleAuthResult, Require2FA } from "@blockshub/blocksdirecte";
 import { useTheme } from "@react-navigation/native";
 import { router } from "expo-router";
@@ -8,47 +8,168 @@ import {
   Alert,
   Keyboard,
   KeyboardAvoidingView,
-  Modal,
   Platform,
   Pressable,
   View,
 } from "react-native";
-import Reanimated, {
-  FadeInDown,
-  FadeOutUp,
-  useSharedValue,
-  withTiming,
-} from "react-native-reanimated";
+import { useSharedValue, withTiming } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import OnboardingBackButton from "@/components/onboarding/OnboardingBackButton";
-import OnboardingInput from "@/components/onboarding/OnboardingInput";
-import OnboardingScrollingFlatList from "@/components/onboarding/OnboardingScrollingFlatList";
 import { useAccountStore } from "@/stores/account";
 import { Account, Services } from "@/stores/account/types";
-import { useAlert } from "@/ui/components/AlertProvider";
 import AnimatedPressable from "@/ui/components/AnimatedPressable";
-import Button from "@/ui/components/Button";
+import { Dynamic } from "@/ui/components/Dynamic";
+import SheetModal from "@/ui/components/SheetModal";
 import Stack from "@/ui/components/Stack";
-import Typography from "@/ui/components/Typography";
+import Button from "@/ui/new/Button";
+import Divider from "@/ui/new/Divider";
+import List from "@/ui/new/List";
+import Typography from "@/ui/new/Typography";
+import { PapillonZoomIn, PapillonZoomOut } from "@/ui/utils/Transition";
+import adjust from "@/utils/adjustColor";
 import uuid from "@/utils/uuid/uuid";
 import { ScrollView } from "react-native-gesture-handler";
 import LoginView from "../../components/LoginView";
 import { useHeaderHeight } from "@react-navigation/elements";
 
 const ANIMATION_DURATION = 170;
+const CHALLENGE_COLOR = "#E50052";
 export const PlatformPressable = Platform.OS === 'android' ? Pressable : AnimatedPressable;
+
+function EDDoubleAuthModal({
+  question,
+  visible,
+  options,
+  selectedIndex,
+  submitting,
+  onClose,
+  onContinue,
+  onSelect,
+}: {
+  question: string;
+  visible: boolean;
+  options: string[];
+  selectedIndex: number | null;
+  submitting: boolean;
+  onClose: () => void;
+  onContinue: () => void;
+  onSelect: (index: number | null) => void;
+}) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+
+  const selectedBackground = adjust(CHALLENGE_COLOR, theme.dark ? -0.82 : 0.92);
+  const selectedBadgeBackground = CHALLENGE_COLOR + (theme.dark ? "22" : "18");
+
+  return (
+    <SheetModal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={{ flex: 1, backgroundColor: colors.background }}>
+        <List
+          ListHeaderComponent={() => (
+            <Stack padding={[4, 0]}>
+              <Typography variant="h2">
+                {question}
+              </Typography>
+              <Divider height={6} ghost />
+              <Typography variant="action" color="textSecondary">
+                {t("ONBOARDING_DOUBLE_AUTH_DESCRIPTION")}
+              </Typography>
+              <Divider height={18} ghost />
+            </Stack>
+          )}
+          contentContainerStyle={{
+            padding: 16,
+            flexGrow: 1,
+            gap: 10,
+            paddingTop: insets.top + 20,
+            paddingBottom: 20,
+          }}
+          style={{ flex: 1 }}
+        >
+          {options.map((option, index) => {
+            const isSelected = selectedIndex === index;
+
+            return (
+              <List.Item
+                key={`${option}-${index}`}
+                onPress={() => {
+                  if (!submitting) {
+                    onSelect(isSelected ? null : index);
+                  }
+                }}
+                style={{
+                  backgroundColor: isSelected ? selectedBackground : colors.card,
+                  minHeight: 68,
+                }}
+              >
+                <List.Leading>
+                  <Stack
+                    width={32}
+                    height={32}
+                    vAlign="center"
+                    hAlign="center"
+                    radius={32}
+                    backgroundColor={isSelected ? selectedBadgeBackground : colors.text + (theme.dark ? "12" : "08")}
+                  >
+                    <Dynamic animated entering={PapillonZoomIn} exiting={PapillonZoomOut}>
+                      {isSelected ? (
+                        <Papicons
+                          name="check"
+                          size={16}
+                          fill={CHALLENGE_COLOR}
+                        />
+                      ) : (
+                        <Typography variant="caption" color="textSecondary">
+                          {index + 1}
+                        </Typography>
+                      )}
+                    </Dynamic>
+                  </Stack>
+                </List.Leading>
+
+                <Typography variant="action" style={{ paddingVertical: 6 }}>
+                  {option}
+                </Typography>
+              </List.Item>
+            );
+          })}
+        </List>
+
+        <View
+          style={{
+            padding: 20,
+            paddingBottom: insets.bottom + 20,
+            borderTopColor: colors.border,
+            borderTopWidth: 1,
+            backgroundColor: colors.background,
+          }}
+        >
+          <Button
+            label={t("ONBOARDING_CONTINUE")}
+            onPress={onContinue}
+            disabled={selectedIndex === null || submitting}
+          />
+        </View>
+      </View>
+    </SheetModal>
+  );
+}
 
 export default function EDLoginWithCredentials() {
   const insets = useSafeAreaInsets();
-  const theme = useTheme();
-  const { colors } = theme;
-
-  const alert = useAlert();
   const { t } = useTranslation();
 
   const [challengeModalVisible, setChallengeModalVisible] = useState<boolean>(false);
   const [doubleAuthChallenge, setDoubleAuthChallenge] = useState<DoubleAuthQuestions | null>(null);
+  const [selectedChallengeIndex, setSelectedChallengeIndex] = useState<number | null>(null);
+  const [isSubmittingChallenge, setIsSubmittingChallenge] = useState<boolean>(false);
 
   const [session, setSession] = useState<Client | null>(null);
   const [token, setToken] = useState<string>();
@@ -83,6 +204,13 @@ export default function EDLoginWithCredentials() {
       hideSub.remove();
     };
   }, [keyboardListeners]);
+
+  useEffect(() => {
+    if (!challengeModalVisible) {
+      setSelectedChallengeIndex(null);
+      setIsSubmittingChallenge(false);
+    }
+  }, [challengeModalVisible]);
 
   const handleLogin = async (username: string, password: string, keys?: DoubleAuthResult) => {
     const client = new Client();
@@ -152,60 +280,20 @@ export default function EDLoginWithCredentials() {
     setIsLoggingIn(false);
   };
 
-  async function handleChallenge(index: number) {
-    setChallengeModalVisible(false);
+  async function handleChallenge() {
+    if (selectedChallengeIndex === null || !session || !doubleAuthChallenge?.propositions?.[selectedChallengeIndex]) { return; }
 
-    if (!session || !doubleAuthChallenge?.propositions?.[index]) { return }
+    setIsSubmittingChallenge(true);
+
     try {
-      const keys = await session.auth.send2FAQuestion(doubleAuthChallenge.propositions[index], token ?? "");
+      const keys = await session.auth.send2FAQuestion(doubleAuthChallenge.propositions[selectedChallengeIndex], token ?? "");
+      setChallengeModalVisible(false);
+      setIsLoggingIn(true);
       queueMicrotask(() => void handleLogin(username, password, keys));
     } catch {
-      throw new Error("2FA challenge failed");
+      setIsSubmittingChallenge(false);
+      Alert.alert(t("Alert_Auth_Error"), t("ONBOARDING_ALERT_LOGIN_ABORTED"));
     }
-  }
-
-  function questionComponent({ item, index }: { item: unknown; index: number }) {
-    return (
-      <Reanimated.View
-        entering={FadeInDown.springify().duration(400).delay(index * 80 + 150)}
-        exiting={FadeOutUp.springify().duration(400).delay(index * 80 + 150)}
-      >
-        <PlatformPressable
-          onPress={() => {
-            handleChallenge(index);
-          }}
-          style={{
-            paddingHorizontal: 10,
-            paddingVertical: 10,
-            paddingRight: 18,
-            borderColor: colors.border,
-            borderWidth: 1.5,
-            borderRadius: 80,
-            flexDirection: "row",
-            alignItems: "center",
-            gap: 16,
-          }}
-        >
-          <Stack
-            width={45}
-            height={45}
-            vAlign="center"
-            hAlign="center"
-            radius={80}
-            backgroundColor={colors.border}
-          >
-            <Typography variant="h4" color={colors.text}>
-              {index + 1}
-            </Typography>
-          </Stack>
-          <Stack gap={0} style={{ width: "80%" }}>
-            <Typography nowrap variant="title" style={{ width: "100%" }}>
-              {String(item)}
-            </Typography>
-          </Stack>
-        </PlatformPressable>
-      </Reanimated.View>
-    );
   }
 
   const headerHeight = useHeaderHeight();
@@ -232,22 +320,16 @@ export default function EDLoginWithCredentials() {
               />
             </ScrollView>
 
-      <Modal
+      <EDDoubleAuthModal
         visible={challengeModalVisible}
-        animationType="slide"
-        presentationStyle="pageSheet"
-        onRequestClose={() => setChallengeModalVisible(false)}
-      >
-        <OnboardingScrollingFlatList
-          title={doubleAuthChallenge?.question ?? t("ONBOARDING_DOUBLE_AUTH")}
-          color={"#E50052"}
-          step={3}
-          hasReturnButton={false}
-          totalSteps={3}
-          elements={doubleAuthChallenge?.propositions ?? []}
-          renderItem={questionComponent}
-        />
-      </Modal>
+        question={doubleAuthChallenge?.question ?? t("ONBOARDING_DOUBLE_AUTH")}
+        options={(doubleAuthChallenge?.propositions ?? []).map((option) => String(option))}
+        selectedIndex={selectedChallengeIndex}
+        submitting={isSubmittingChallenge}
+        onSelect={setSelectedChallengeIndex}
+        onClose={() => setChallengeModalVisible(false)}
+        onContinue={handleChallenge}
+      />
     </KeyboardAvoidingView>
   );
 }

--- a/app/(settings)/edit_subject.tsx
+++ b/app/(settings)/edit_subject.tsx
@@ -1,5 +1,6 @@
 import Stack from "@/ui/components/Stack";
 import AnimatedPressable from "@/ui/components/AnimatedPressable";
+import SheetModal from "@/ui/components/SheetModal";
 import { Papicons } from "@getpapillon/papicons";
 import { useTheme } from "@react-navigation/native";
 import Typography from "@/ui/components/Typography";
@@ -9,7 +10,6 @@ import {
   ScrollView,
   View,
   Platform,
-  Modal,
 } from "react-native";
 import OnboardingInput from "@/components/onboarding/OnboardingInput";
 import { Colors } from "@/utils/subjects/colors";
@@ -112,7 +112,12 @@ function EmojiPicker({
     setSelectedEmoji(item);
   }, []);
 
-  const [headerHeight, setHeaderHeight] = useState(0);
+  const estimatedHeaderHeight = useMemo(() => {
+    const usedInsets = Platform.OS === "ios" ? 16 : insets.top;
+    return usedInsets + 4 + 40 + 16 + (Platform.OS === "android" ? 6 : 0);
+  }, [insets.top]);
+  const [measuredHeaderHeight, setMeasuredHeaderHeight] = useState(0);
+  const headerHeight = Math.max(measuredHeaderHeight, estimatedHeaderHeight);
   const [selectedEmoji, setSelectedEmoji] = useState<string>("😀");
 
   const emojiContainerStyle = {
@@ -145,7 +150,7 @@ function EmojiPicker({
     >
       <TabHeader
         modal={Platform.OS === "ios"}
-        onHeightChanged={setHeaderHeight}
+        onHeightChanged={setMeasuredHeaderHeight}
         title={
           <TabHeaderTitle
             chevron={false}
@@ -420,7 +425,7 @@ export default function EditSubject() {
           style={{ width: Dimensions.get("window").width }}
           contentContainerStyle={{
             gap: 10,
-            height: 60,
+            height: 62,
             alignItems: "center",
             paddingHorizontal: 16,
           }}
@@ -487,7 +492,7 @@ export default function EditSubject() {
           ))}
         </ScrollView>
       </Stack>
-      <Modal
+      <SheetModal
         presentationStyle={"formSheet"}
         animationType={"slide"}
         visible={showEmojiPicker}
@@ -500,7 +505,7 @@ export default function EditSubject() {
             setShowEmojiPicker(false);
           }}
         />
-      </Modal>
+      </SheetModal>
     </View>
   );
 };

--- a/app/(settings)/transport.tsx
+++ b/app/(settings)/transport.tsx
@@ -3,11 +3,12 @@ import { useTheme } from "@react-navigation/native";
 import * as React from "react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Image, Modal } from "react-native";
+import { Image } from "react-native";
 
 import SettingsHeader from "@/components/SettingsHeader";
 import { AvailableTransportServices } from "@/constants/AvailableTransportServices";
 import { useAccountStore } from "@/stores/account";
+import SheetModal from "@/ui/components/SheetModal";
 import List from "@/ui/new/List";
 import Typography from "@/ui/new/Typography";
 import { AddressModal } from "@/app/(modals)/address";
@@ -178,7 +179,7 @@ export default function TransportView() {
         ))}
       </List.Section>
       <List.View>
-        <Modal
+        <SheetModal
           presentationStyle={"pageSheet"}
           visible={showAddressSelect}
           allowSwipeDismissal={true}
@@ -199,7 +200,7 @@ export default function TransportView() {
               setShowAddressSelect(false);
             }}
           />
-        </Modal>
+        </SheetModal>
       </List.View>
     </List>
   );

--- a/locales/en.json
+++ b/locales/en.json
@@ -113,6 +113,7 @@
   "ONBOARDING_UNKNOWN_STUDENT": "Student",
   "ONBOARDING_DEFAULT_USER_FIRSTNAME": "User",
   "ONBOARDING_DOUBLE_AUTH": "Double authentication",
+  "ONBOARDING_DOUBLE_AUTH_DESCRIPTION": "Select the right answer, then continue.",
   "ONBOARDING_OTHER_UNIVERSITIES": "Other universities",
   "ONBOARDING_SERVICE_PRONOTE": "PRONOTE",
   "ONBOARDING_SERVICE_ED": "ÉcoleDirecte",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -116,6 +116,7 @@
   "ONBOARDING_UNKNOWN_STUDENT": "Étudiant",
   "ONBOARDING_DEFAULT_USER_FIRSTNAME": "Utilisateur",
   "ONBOARDING_DOUBLE_AUTH": "Double authentification",
+  "ONBOARDING_DOUBLE_AUTH_DESCRIPTION": "Sélectionne la bonne réponse, puis continue.",
   "ONBOARDING_OTHER_UNIVERSITIES": "Autres universités",
   "ONBOARDING_SERVICE_PRONOTE": "PRONOTE",
   "ONBOARDING_SERVICE_ED": "ÉcoleDirecte",

--- a/ui/components/SheetModal.tsx
+++ b/ui/components/SheetModal.tsx
@@ -1,0 +1,101 @@
+import React, { PropsWithChildren, useEffect, useState } from "react";
+import { Modal, ModalProps, Platform, StyleSheet, useWindowDimensions } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import Animated, { Easing, runOnJS, useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
+
+const OPEN_DURATION = 220;
+const CLOSE_DURATION = 180;
+
+type SheetModalProps = PropsWithChildren<ModalProps>;
+
+export default function SheetModal({
+  animationType = "slide",
+  children,
+  visible = false,
+  ...props
+}: SheetModalProps) {
+  const { height } = useWindowDimensions();
+  const [isMounted, setIsMounted] = useState(visible);
+  const translateY = useSharedValue(visible ? 0 : height);
+
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+
+    if (visible) {
+      if (!isMounted) {
+        setIsMounted(true);
+        translateY.value = height;
+      }
+
+      translateY.value = withTiming(0, {
+        duration: OPEN_DURATION,
+        easing: Easing.out(Easing.cubic),
+      });
+      return;
+    }
+
+    if (!isMounted) {
+      translateY.value = height;
+      return;
+    }
+
+    // Android unmounts Modal children as soon as `visible` becomes false.
+    translateY.value = withTiming(
+      height,
+      {
+        duration: CLOSE_DURATION,
+        easing: Easing.in(Easing.cubic),
+      },
+      finished => {
+        if (finished) {
+          runOnJS(setIsMounted)(false);
+        }
+      }
+    );
+  }, [height, isMounted, translateY, visible]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  if (Platform.OS !== "android") {
+    return (
+      <Modal
+        {...props}
+        animationType={animationType}
+        visible={visible}
+      >
+        {children}
+      </Modal>
+    );
+  }
+
+  if (!visible && !isMounted) {
+    return null;
+  }
+
+  return (
+    <Modal
+      {...props}
+      animationType="none"
+      navigationBarTranslucent
+      statusBarTranslucent
+      transparent
+      visible
+    >
+      <GestureHandlerRootView style={styles.container}>
+        <Animated.View style={[styles.container, animatedStyle]}>
+          {children}
+        </Animated.View>
+      </GestureHandlerRootView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
Introduce a new SheetModal component (Android-friendly animated sheet) and replace raw Modal usages with SheetModal in several screens (ED credentials, edit_subject, transport). Refactor the ÉcoleDirecte login flow: extract EDDoubleAuthModal, replace animated list item implementation with a sheet-based selectable list, add selection/submission state handling, and queue 2FA responses into the existing login flow. Update edit_subject header height calculation and minor layout tweaks. Add localized strings for double-auth description (en/fr) and import/update various UI primitives (List, Button, Typography, Papicons) and helper utilities.

![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [x] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [x] Cette Pull Request n'est pas faite essentiellement avec de l'IA.
- [x] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [x] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [ ] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [x] J’emploie un langage informel, clair et concis dans mes messages.
- [x] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [x] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.
