### PR TITLE
feat: Add Dialog component and provider

### DIFF
--- a/components/AppProviders.tsx
+++ b/components/AppProviders.tsx
@@ -7,6 +7,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { DatabaseProvider } from "@/database/DatabaseProvider";
 import { DEFAULT_MATERIAL_YOU_ENABLED, useSettingsStore } from '@/stores/settings';
 import { AlertProvider } from '@/ui/components/AlertProvider';
+import { DialogProvider } from '@/ui/components/DialogProvider';
 import { runsIOS26 } from '@/ui/utils/IsLiquidGlass';
 import { AppColors } from "@/utils/colors";
 import { createDarkTheme, createDefaultTheme } from '@/utils/theme/Theme';
@@ -53,9 +54,11 @@ export function AppProviders({ children }: AppProvidersProps) {
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: "black" }}>
       <DatabaseProvider>
         <ThemeProvider value={theme}>
-          <AlertProvider>
-            {children}
-          </AlertProvider>
+          <DialogProvider>
+            <AlertProvider>
+              {children}
+            </AlertProvider>
+          </DialogProvider>
         </ThemeProvider>
       </DatabaseProvider>
     </GestureHandlerRootView>

--- a/ui/components/Dialog.tsx
+++ b/ui/components/Dialog.tsx
@@ -1,0 +1,345 @@
+import React from "react";
+import type { AlertButton } from "react-native";
+import { Dimensions, Modal, Pressable, StyleSheet, View } from "react-native";
+import { useTheme } from "@react-navigation/native";
+import { Papicons } from "@getpapillon/papicons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Reanimated, { FadeIn, FadeOut } from "react-native-reanimated";
+
+import Button, { type Color as ButtonColor } from "./Button";
+import Typography from "../new/Typography";
+import { PapillonSpringIn } from "../utils/Transition";
+
+export type DialogButton = AlertButton;
+
+type DialogActionProps = {
+  action: DialogButton;
+  filled?: boolean;
+  color: ButtonColor;
+  fullWidth?: boolean;
+  onPress: () => void;
+};
+
+type DialogProps = {
+  visible: boolean;
+  modalVisible: boolean;
+  title?: string | null;
+  message?: string | null;
+  buttons?: DialogButton[];
+  cancelable?: boolean;
+  onDismiss: () => void;
+  onPressButton: (button: DialogButton, index: number) => void;
+};
+
+function DialogAction({
+  action,
+  filled = false,
+  color,
+  fullWidth = false,
+  onPress,
+}: DialogActionProps) {
+  const variant = filled ? "primary" : "ghost";
+
+  return (
+    <View
+      style={[
+        styles.actionContainer,
+        filled && styles.actionFilledContainer,
+        fullWidth && styles.actionFullWidth,
+      ]}
+    >
+      <Button
+        title={action.text ?? "OK"}
+        onPress={onPress}
+        variant={variant}
+        color={color}
+        inline={!fullWidth}
+        style={styles.actionButton}
+      />
+    </View>
+  );
+}
+
+export default function Dialog({
+  visible,
+  modalVisible,
+  title,
+  message,
+  buttons = [],
+  cancelable = false,
+  onDismiss,
+  onPressButton,
+}: DialogProps) {
+  const theme = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const normalizedButtons = buttons.length > 0 ? buttons : [{ text: "OK" }];
+  const destructiveColor = (colors as any).danger ?? "#D70000";
+  const cardColor =
+    (colors as typeof colors & { item?: string }).item ?? colors.card;
+  const dialogWidth = Math.min(
+    Dimensions.get("window").width - insets.left - insets.right - 32,
+    360
+  );
+  const content = `${title ?? ""} ${message ?? ""}`.toLowerCase();
+  const dangerTone =
+    normalizedButtons.some(button => button.style === "destructive") ||
+    ["erreur", "error", "impossible", "echec", "échec", "failed"].some(
+      keyword => content.includes(keyword)
+    );
+  const accentColor = dangerTone ? destructiveColor : colors.primary;
+  const heroColor = dangerTone ? `${accentColor}20` : `${accentColor}18`;
+  const hasCompactActions = normalizedButtons.length <= 2;
+  const hasSingleAction = normalizedButtons.length === 1;
+  const primaryAction = normalizedButtons[normalizedButtons.length - 1];
+  const secondaryActions = normalizedButtons.slice(0, -1);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      statusBarTranslucent
+      animationType="none"
+      onRequestClose={() => {
+        if (cancelable) {
+          onDismiss();
+        }
+      }}
+    >
+      <Pressable
+        style={[styles.backdrop, { backgroundColor: "rgba(0, 0, 0, 0.24)" }]}
+        onPress={cancelable ? onDismiss : undefined}
+      />
+      {modalVisible && (
+        <Reanimated.View
+          style={styles.container}
+          pointerEvents="box-none"
+          entering={FadeIn.duration(160)}
+          exiting={FadeOut.duration(200)}
+        >
+          <Reanimated.View
+            entering={PapillonSpringIn}
+            exiting={FadeOut.duration(200)}
+            style={[
+              styles.dialog,
+              {
+                backgroundColor: cardColor,
+                borderColor: colors.border,
+                width: dialogWidth,
+              },
+            ]}
+          >
+            <View style={[styles.hero, { backgroundColor: heroColor }]}>
+              <View style={styles.heroIconContainer}>
+                <Papicons name="Butterfly" color={accentColor} size={84} />
+              </View>
+            </View>
+
+            {(title || message) && (
+              <View style={styles.content}>
+                {title ? (
+                  <Typography variant="h4" weight="bold">
+                    {title}
+                  </Typography>
+                ) : null}
+                {message ? (
+                  <Typography
+                    variant="body1"
+                    color={theme.dark ? "textSecondary" : colors.text}
+                    style={title ? styles.message : undefined}
+                  >
+                    {message}
+                  </Typography>
+                ) : null}
+              </View>
+            )}
+
+            {hasCompactActions ? (
+              <View
+                style={[
+                  styles.compactActions,
+                  hasSingleAction && styles.compactActionsSingle,
+                ]}
+              >
+                {!hasSingleAction && secondaryActions.length > 0 ? (
+                  <View style={styles.secondaryActions}>
+                    {secondaryActions.map((button, index) => (
+                      <DialogAction
+                        key={`${button.text ?? "button"}-${index}`}
+                        action={button}
+                        color={
+                          button.style === "destructive" ? "danger" : "text"
+                        }
+                        fullWidth
+                        onPress={() => onPressButton(button, index)}
+                      />
+                    ))}
+                  </View>
+                ) : !hasSingleAction ? (
+                  <View style={styles.secondarySpacer} />
+                ) : null}
+
+                <View
+                  style={[
+                    styles.primaryAction,
+                    hasSingleAction && styles.primaryActionFull,
+                  ]}
+                >
+                  <DialogAction
+                    action={primaryAction}
+                    filled
+                    fullWidth
+                    color={
+                      primaryAction.style === "destructive" || dangerTone
+                        ? "danger"
+                        : "primary"
+                    }
+                    onPress={() =>
+                      onPressButton(primaryAction, normalizedButtons.length - 1)
+                    }
+                  />
+                </View>
+              </View>
+            ) : (
+              <View
+                style={[
+                  styles.actions,
+                  {
+                    borderTopWidth: title || message ? 0.5 : 0,
+                    borderTopColor: colors.text + "18",
+                  },
+                ]}
+              >
+                {normalizedButtons.map((button, index) => (
+                  <View
+                    key={`${button.text ?? "button"}-${index}`}
+                    style={[
+                      styles.stackedAction,
+                      index > 0 && {
+                        borderTopWidth: 0.5,
+                        borderTopColor: colors.text + "18",
+                      },
+                    ]}
+                  >
+                    <DialogAction
+                      action={button}
+                      color={
+                        button.style === "destructive" ? "danger" : "primary"
+                      }
+                      fullWidth
+                      onPress={() => onPressButton(button, index)}
+                    />
+                  </View>
+                ))}
+              </View>
+            )}
+          </Reanimated.View>
+        </Reanimated.View>
+      )}
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.0)",
+  },
+  container: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  dialog: {
+    borderRadius: 32,
+    borderWidth: 0.5,
+    overflow: "hidden",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.16,
+    shadowRadius: 18,
+    elevation: 10,
+    maxWidth: 360,
+  },
+  hero: {
+    height: 158,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  heroIconContainer: {
+    width: 116,
+    height: 116,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  heroBadge: {
+    position: "absolute",
+    right: 8,
+    bottom: 8,
+    borderRadius: 99,
+    padding: 2,
+  },
+  content: {
+    paddingHorizontal: 22,
+    paddingTop: 16,
+    paddingBottom: 10,
+  },
+  message: {
+    marginTop: 4,
+  },
+  actions: {
+    overflow: "hidden",
+  },
+  compactActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 18,
+    paddingTop: 8,
+    paddingBottom: 18,
+  },
+  compactActionsSingle: {
+    paddingTop: 12,
+  },
+  secondaryActions: {
+    flex: 1,
+  },
+  secondarySpacer: {
+    flex: 1,
+  },
+  primaryAction: {
+    minWidth: 168,
+    maxWidth: "62%",
+  },
+  primaryActionFull: {
+    minWidth: 0,
+    maxWidth: "100%",
+    flex: 1,
+  },
+  actionContainer: {
+    borderRadius: 999,
+    overflow: "hidden",
+  },
+  actionButton: {
+    minHeight: 52,
+  },
+  actionFullWidth: {
+    width: "100%",
+  },
+  actionFilledContainer: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  stackedAction: {
+    borderRadius: 0,
+    overflow: "hidden",
+  },
+});

--- a/ui/components/DialogProvider.tsx
+++ b/ui/components/DialogProvider.tsx
@@ -1,0 +1,185 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Alert,
+  type AlertButton,
+  type AlertOptions,
+  Platform,
+} from "react-native";
+
+import Dialog from "./Dialog";
+
+type DialogRequest = {
+  title?: string | null;
+  message?: string | null;
+  buttons: AlertButton[];
+  options?: AlertOptions;
+};
+
+type DialogContextType = {
+  showDialog: typeof Alert.alert;
+};
+
+const DialogContext = createContext<DialogContextType | undefined>(undefined);
+const globalWithOriginalAlert = globalThis as typeof globalThis & {
+  __papillonOriginalAlert?: typeof Alert.alert;
+};
+
+if (!globalWithOriginalAlert.__papillonOriginalAlert) {
+  globalWithOriginalAlert.__papillonOriginalAlert = Alert.alert;
+}
+
+export function useDialog() {
+  const context = useContext(DialogContext);
+  if (!context) {
+    throw new Error("useDialog must be used within a DialogProvider");
+  }
+  return context;
+}
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const queueRef = useRef<DialogRequest[]>([]);
+  const currentDialogRef = useRef<DialogRequest | null>(null);
+  const openTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showDialogRef = useRef<typeof Alert.alert>(() => {});
+
+  const [visible, setVisible] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [currentDialog, setCurrentDialog] = useState<DialogRequest | null>(
+    null
+  );
+
+  function clearTimer(
+    timerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>
+  ) {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }
+
+  function openNextDialog() {
+    if (currentDialogRef.current) {
+      return;
+    }
+
+    const nextDialog = queueRef.current.shift();
+    if (!nextDialog) {
+      return;
+    }
+
+    clearTimer(closeTimeoutRef);
+    clearTimer(openTimeoutRef);
+    currentDialogRef.current = nextDialog;
+    setCurrentDialog(nextDialog);
+    setVisible(true);
+    openTimeoutRef.current = setTimeout(() => {
+      setModalVisible(true);
+    }, 0);
+  }
+
+  function showDialog(
+    title: string | null | undefined,
+    message?: string | null,
+    buttons?: AlertButton[],
+    options?: AlertOptions
+  ) {
+    queueRef.current.push({
+      title,
+      message,
+      buttons: buttons?.length ? buttons : [{ text: "OK" }],
+      options,
+    });
+    openNextDialog();
+  }
+
+  function closeDialog(button?: AlertButton, dismissed?: boolean) {
+    const dialog = currentDialogRef.current;
+    if (!dialog) {
+      return;
+    }
+
+    clearTimer(openTimeoutRef);
+    setModalVisible(false);
+    clearTimer(closeTimeoutRef);
+    closeTimeoutRef.current = setTimeout(() => {
+      currentDialogRef.current = null;
+      setVisible(false);
+      setCurrentDialog(null);
+
+      if (dismissed) {
+        dialog.options?.onDismiss?.();
+      } else {
+        button?.onPress?.();
+      }
+
+      openNextDialog();
+    }, 220);
+  }
+
+  useEffect(() => {
+    showDialogRef.current = showDialog;
+  });
+
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+
+    Alert.alert = ((title, message, buttons, options) => {
+      showDialogRef.current(title, message, buttons, options);
+    }) as typeof Alert.alert;
+
+    return () => {
+      Alert.alert = globalWithOriginalAlert.__papillonOriginalAlert!;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearTimer(openTimeoutRef);
+      clearTimer(closeTimeoutRef);
+      queueRef.current = [];
+      currentDialogRef.current = null;
+    };
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      showDialog,
+    }),
+    []
+  );
+
+  return (
+    <DialogContext.Provider value={contextValue}>
+      {children}
+      {Platform.OS === "android" && currentDialog ? (
+        <Dialog
+          visible={visible}
+          modalVisible={modalVisible}
+          title={currentDialog.title}
+          message={currentDialog.message}
+          buttons={currentDialog.buttons}
+          cancelable={currentDialog.options?.cancelable}
+          onDismiss={() => {
+            if (currentDialog.options?.cancelable) {
+              closeDialog(undefined, true);
+            }
+          }}
+          onPressButton={button => {
+            closeDialog(button, false);
+          }}
+        />
+      ) : null}
+    </DialogContext.Provider>
+  );
+}


### PR DESCRIPTION
Introduce a new Dialog UI component and DialogProvider to handle app alerts/dialogs. The Dialog implements a themed, animated modal with hero artwork, danger-tone detection, compact/stacked action layouts and full button handling. DialogProvider queues dialog requests, overrides Alert.alert on Android to route through the provider, and manages show/close animations and timeouts; it is registered in AppProviders to wrap the app. Also updated AppProviders to include the DialogProvider around AlertProvider.

![Contribution](https://github.com/PapillonApp/papillon-v8/raw/main/.github/assets/contribution_header.png)

# Règles de contribution
> [!CAUTION]
> Afin de garantir une application stable et pérenne dans le temps, nous t'invitons à vérifier que tu as bien respecté les règles de contribution. Sans cela, ta Pull Request ne pourra pas être examinée.

- [x] Cette Pull Request porte sur une seule fonctionnalité ou un seul correctif.
- [x] Cette Pull Request n'est pas faite essentiellement avec de l'IA.
- [x] Pour tout changement majeur, j’ai créé une issue afin d’échanger avec les mainteneurs de Papillon sur la meilleure façon de l’intégrer.
- [x] Ma Pull Request respecte les conventions Conventional Commits et Conventional Branch ainsi que les conventions de codage de l'application.
- [x] J’ai testé mes modifications sur iOS et Android, et l’application fonctionne correctement.
- [x] J’emploie un langage informel, clair et concis dans mes messages.
- [x] J’ai documenté mes changements de manière appropriée, soit dans la description de la Pull Request, soit dans le GitBook.
- [x] J’ai ajouté les traductions nécessaires dans au moins un fichier de langue.

# Informations supplémentaires
> [!NOTE]
> Numéro des issues concernées par cette Pull Request, détail sur le fonctionnement ou les choix techniques effectués, ainsi que toute autre information pertinente.
<img width="636" height="965" alt="image" src="https://github.com/user-attachments/assets/a50e9901-42ce-4bd1-9b31-4479dac38b58" />
<img width="614" height="851" alt="image" src="https://github.com/user-attachments/assets/50964098-e1d0-4439-b486-20795b8de7e0" />
