### PR TITLE
chore: Next course Bottom Accessory

### DIFF
--- a/app/(settings)/_layout.tsx
+++ b/app/(settings)/_layout.tsx
@@ -138,6 +138,15 @@ export default function Layout() {
             headerTitle: t("Settings_Transport_Title"),
           }}
         />
+        <Stack.Screen
+          name="features"
+          options={{
+            headerTitle: t("Settings_Features_Title"),
+            headerBackButtonDisplayMode: "minimal",
+            headerTransparent: false,
+            headerLargeTitle: false,
+          }}
+        />
       </Stack>
     </>
   );

--- a/app/(settings)/features.tsx
+++ b/app/(settings)/features.tsx
@@ -1,0 +1,81 @@
+import { Papicons } from "@getpapillon/papicons";
+import { Platform } from "react-native";
+
+import { useSettingsStore } from "@/stores/settings";
+import List from "@/ui/new/List";
+import Typography from "@/ui/new/Typography";
+import NativeSwitch from "@/ui/native/NativeSwitch";
+import { useTranslation } from "react-i18next";
+import Icon from "@/ui/components/Icon";
+
+export default function SettingsFeatures() {
+  const { t } = useTranslation();
+
+  const settingsStore = useSettingsStore(state => state.personalization);
+  const mutateProperty = useSettingsStore(state => state.mutateProperty);
+
+  const iOSBottomAccessoryEnabled = settingsStore.iOSBottomAccessoryEnabled ?? true;
+  const showTabBarLabels = settingsStore.showTabBarLabels ?? true;
+
+  return (
+    <List
+      contentInsetAdjustmentBehavior="always"
+      contentContainerStyle={{ padding: 16 }}
+      style={{ flex: 1 }}
+    >
+      <List.Section>
+        <List.SectionTitle>
+          <List.Label>{t("Settings_Features_TabBar")}</List.Label>
+        </List.SectionTitle>
+
+        {Platform.OS === "ios" && (
+          <List.Item>
+            <List.Leading>
+              <Icon>
+                <Papicons name={"Sunrise"} />
+              </Icon>
+            </List.Leading>
+            <Typography variant="title">{t("Settings_Features_BottomAccessory")}</Typography>
+            <Typography color="textSecondary" numberOfLines={2}>
+              {t("Settings_Features_BottomAccessory_Description")}
+            </Typography>
+            <List.Trailing>
+              <NativeSwitch
+                value={Platform.OS !== "ios" ? false : iOSBottomAccessoryEnabled}
+                disabled={Platform.OS !== "ios"}
+                onValueChange={(value) =>
+                  mutateProperty("personalization", {
+                    ...settingsStore,
+                    iOSBottomAccessoryEnabled: value,
+                  })
+                }
+              />
+            </List.Trailing>
+          </List.Item>
+        )}
+        <List.Item>
+          <List.Leading>
+            <Icon>
+              <Papicons name={"Font"} />
+            </Icon>
+          </List.Leading>
+          <Typography variant="title">{t("Settings_Features_ShowTabBarLabels")}</Typography>
+          <Typography color="textSecondary" numberOfLines={2}>
+            {t("Settings_Features_ShowTabBarLabels_Description")}
+          </Typography>
+          <List.Trailing>
+            <NativeSwitch
+              value={showTabBarLabels}
+              onValueChange={(value) =>
+                mutateProperty("personalization", {
+                  ...settingsStore,
+                  showTabBarLabels: value,
+                })
+              }
+            />
+          </List.Trailing>
+        </List.Item>
+      </List.Section>
+    </List>
+  );
+}

--- a/app/(settings)/settings.tsx
+++ b/app/(settings)/settings.tsx
@@ -86,6 +86,13 @@ export default function SettingsIndex() {
           color: "#000",
           onPress: () => router.navigate("/(settings)/transport"),
         },
+        {
+          title: t("Settings_Features_Title"),
+          description: t("Settings_Features_Description"),
+          papicon: <Papicons name={"Sparkles"} />,
+          color: "#0059DD",
+          onPress: () => router.navigate("/(settings)/features"),
+        },
       ],
     },
     {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,3 +1,4 @@
+import BottomAccessory from '@/components/BottomAccessory';
 import { runsIOS26 } from '@/ui/utils/IsLiquidGlass';
 import { useTheme } from '@react-navigation/native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
@@ -25,7 +26,12 @@ export default function TabLayout() {
       rippleColor={theme.colors.tint + '22'}
       backgroundColor={Platform.OS === 'android' ? theme.colors.background : undefined}
       sidebarAdaptable
+      minimizeBehavior="onScrollDown"
     >
+      <NativeTabs.BottomAccessory>
+        <BottomAccessory />
+      </NativeTabs.BottomAccessory>
+
       <NativeTabs.Trigger name="index">
         <NativeTabs.Trigger.Label>{t("Tab_Home")}</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={IS_IOS_WITH_PADDING ? require('@/assets/icons/home_padding.png') : require('@/assets/icons/home.png')} renderingMode='template' />

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,4 +1,5 @@
 import BottomAccessory from '@/components/BottomAccessory';
+import { useSettingsStore } from '@/stores/settings';
 import { runsIOS26 } from '@/ui/utils/IsLiquidGlass';
 import { useTheme } from '@react-navigation/native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
@@ -6,50 +7,65 @@ import { useTranslation } from 'react-i18next';
 import { Platform } from 'react-native';
 
 // Static platform detection - computed once at module load
-const IS_IOS_WITH_PADDING = runsIOS26;
+const IS_IOS_WITH_PADDING = false;
 const IS_ANDROID = Platform.OS === 'android';
 
 const TAB_LABEL_STYLE = {
   fontFamily: 'medium',
-  fontSize: Platform.OS === 'ios' ? 13 : 13,
+  fontSize: Platform.OS === 'ios' ? 12 : 13,
 } as const;
 
 export default function TabLayout() {
   const theme = useTheme();
   const { t } = useTranslation();
 
+
+  const settingsStore = useSettingsStore(state => state.personalization);
+  const disabledTabs = settingsStore?.disabledTabs || [];
+
+  const iOSBottomAccessoryEnabled = settingsStore?.iOSBottomAccessoryEnabled ?? true;
+  const showTabBarLabels = settingsStore?.showTabBarLabels ?? true;
+  const labelsHidden = Platform.OS === 'ios' ? !showTabBarLabels : false;
+
+  const shouldRenderBottomAccessory =
+    Platform.OS !== 'ios' || iOSBottomAccessoryEnabled;
+
   return (
     <NativeTabs
       tintColor={theme.colors.tint}
       labelStyle={TAB_LABEL_STYLE}
-      labelVisibilityMode="labeled"
+      labelVisibilityMode={showTabBarLabels ? "labeled" : "selected"}
       rippleColor={theme.colors.tint + '22'}
       backgroundColor={Platform.OS === 'android' ? theme.colors.background : undefined}
       sidebarAdaptable
-      minimizeBehavior="onScrollDown"
+      minimizeBehavior={iOSBottomAccessoryEnabled ? "onScrollDown" : "never"}
+      disableTransparentOnScrollEdge
+      titlePositionAdjustment={runsIOS26 ? { vertical: 6, horizontal: 0 } : undefined}
     >
-      <NativeTabs.BottomAccessory>
-        <BottomAccessory />
-      </NativeTabs.BottomAccessory>
+      {shouldRenderBottomAccessory && (
+        <NativeTabs.BottomAccessory>
+          <BottomAccessory />
+        </NativeTabs.BottomAccessory>
+      )}
 
-      <NativeTabs.Trigger name="index">
-        <NativeTabs.Trigger.Label>{t("Tab_Home")}</NativeTabs.Trigger.Label>
+      <NativeTabs.Trigger name="index"  hidden={disabledTabs.includes('home')}>
+        <NativeTabs.Trigger.Label hidden={labelsHidden}>{t("Tab_Home")}</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={IS_IOS_WITH_PADDING ? require('@/assets/icons/home_padding.png') : require('@/assets/icons/home.png')} renderingMode='template' />
       </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="calendar">
-        <NativeTabs.Trigger.Label>{t("Tab_Calendar")}</NativeTabs.Trigger.Label>
+      <NativeTabs.Trigger name="calendar" hidden={disabledTabs.includes('calendar')}>
+        <NativeTabs.Trigger.Label hidden={labelsHidden}>{t("Tab_Calendar")}</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={IS_IOS_WITH_PADDING ? require('@/assets/icons/calendar_padding.png') : require('@/assets/icons/calendar.png')} renderingMode='template' />
       </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="tasks">
-        <NativeTabs.Trigger.Label>{t("Tab_Tasks")}</NativeTabs.Trigger.Label>
+      <NativeTabs.Trigger name="tasks" hidden={disabledTabs.includes('tasks')}>
+        <NativeTabs.Trigger.Label hidden={labelsHidden}>{t("Tab_Tasks")}</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={IS_IOS_WITH_PADDING ? require('@/assets/icons/tasks_padding.png') : require('@/assets/icons/tasks.png')} renderingMode='template' />
       </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="grades">
-        <NativeTabs.Trigger.Label>{t("Tab_Grades")}</NativeTabs.Trigger.Label>
+      <NativeTabs.Trigger name="grades" hidden={disabledTabs.includes('grades')}>
+        <NativeTabs.Trigger.Label hidden={labelsHidden}>{t("Tab_Grades")}</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={IS_IOS_WITH_PADDING ? require('@/assets/icons/pie_padding.png') : require('@/assets/icons/pie.png')} renderingMode='template' />
       </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="news">
-        <NativeTabs.Trigger.Label>{t("Tab_News")}</NativeTabs.Trigger.Label>
+      <NativeTabs.Trigger name="news" hidden={disabledTabs.includes('news')}>
+        <NativeTabs.Trigger.Label hidden={labelsHidden}>{t("Tab_News")}</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={IS_IOS_WITH_PADDING ? require('@/assets/icons/newspaper_padding.png') : require('@/assets/icons/newspaper.png')} renderingMode='template' />
       </NativeTabs.Trigger>
     </NativeTabs>

--- a/app/(tabs)/index/hooks/useTimetableWidgetData.ts
+++ b/app/(tabs)/index/hooks/useTimetableWidgetData.ts
@@ -8,6 +8,7 @@ export const useTimetableWidgetData = () => {
   const now = new Date();
   const weekNumber = getWeekNumberFromDate(now);
 
+  const [loading, setLoading] = useState(false);
   const accounts = useAccountStore((state) => state.accounts);
   const lastUsedAccount = useAccountStore((state) => state.lastUsedAccount);
   const account = accounts.find((a) => a.id === lastUsedAccount);
@@ -32,6 +33,7 @@ export const useTimetableWidgetData = () => {
 
   useEffect(() => {
     const fetchData = async () => {
+      setLoading(true);
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
@@ -49,6 +51,7 @@ export const useTimetableWidgetData = () => {
 
       dayCourse = dayCourse.filter(course => course.to.getTime() > Date.now());
       setCourses(dayCourse);
+      setLoading(false);
     };
     fetchData();
   }, [weeklyTimetable]);

--- a/app/(tabs)/index/index.tsx
+++ b/app/(tabs)/index/index.tsx
@@ -111,11 +111,11 @@ const HomeViewContainer = ({ children }) => {
       maskElement={
         <View style={{ flex: 1, backgroundColor: 'transparent' }}>
           <LinearGradient
-            colors={['#ff000022', 'red']}
+            colors={['#ff000022', 'white']}
             locations={[0.5, 1]}
             style={{ height: insets.top + 68 }}
           />
-          <View style={{ flex: 1, backgroundColor: 'red' }} />
+          <View style={{ flex: 1, backgroundColor: 'white' }} />
         </View>
       }
       style={{ flex: 1 }}

--- a/components/BottomAccessory.tsx
+++ b/components/BottomAccessory.tsx
@@ -1,0 +1,214 @@
+import { useTimetableWidgetData } from '@/app/(tabs)/index/hooks/useTimetableWidgetData';
+import Icon from '@/ui/components/Icon';
+import Typography from '@/ui/new/Typography';
+import i18n from '@/utils/i18n';
+import { getSubjectColor } from '@/utils/subjects/colors';
+import { getSubjectEmoji } from '@/utils/subjects/emoji';
+import { getSubjectName } from '@/utils/subjects/name';
+import { Papicons } from '@getpapillon/papicons';
+import { useTheme } from '@react-navigation/native';
+import { formatDistanceToNowStrict } from 'date-fns';
+import * as DateLocale from 'date-fns/locale';
+import { useNavigation } from 'expo-router';
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
+import React from 'react';
+import { ActivityIndicator, Pressable } from 'react-native';
+import { View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+function NextCourseAccessory({ placement }) {
+  const theme = useTheme();
+  const { courses, loading } = useTimetableWidgetData();
+  const nextCourse = courses.length > 0 ? courses[0] : null;
+
+  if(!nextCourse) {
+    return null;
+  }
+
+  // if (placement === 'inline') {}
+
+  const sbjColor = getSubjectColor(nextCourse.subject);
+  const navigation = useNavigation<any>();
+
+  if(loading) {
+    return (
+      <View
+        style={{
+          height: "100%",
+          paddingVertical: 10,
+          paddingHorizontal: 14,
+          alignItems: "center",
+          justifyContent: "center",
+          flexDirection: "row",
+          gap: 10,
+        }}
+      >
+        <ActivityIndicator />
+        <Typography variant="body1" weight="semibold" color="textSecondary">
+          Chargement des cours...
+        </Typography>
+      </View>
+    )
+  }
+
+  if(!nextCourse) {
+    return (
+      <View
+        style={{
+          height: "100%",
+          paddingVertical: 10,
+          paddingHorizontal: 14,
+          alignItems: "center",
+          justifyContent: "center",
+          flexDirection: "row",
+          gap: 10,
+        }}
+      >
+        <Typography variant="body1" weight="semibold" color="textSecondary">
+          Aucun cours à venir prochainement
+        </Typography>
+      </View>
+    )
+  }
+
+  return (
+    <>
+      <Pressable
+        onPress={() => {
+          navigation.navigate("(modals)/course", {
+            course: nextCourse,
+            subjectInfo: {
+              id: nextCourse.subject,
+              name: getSubjectName(nextCourse.subject),
+              color: getSubjectColor(nextCourse.subject) || theme.colors.primary,
+              emoji: getSubjectEmoji(nextCourse.subject),
+            },
+          });
+        }}
+        style={{
+          height: "100%",
+          paddingVertical: 10,
+          paddingHorizontal: 14,
+          alignItems: "center",
+          justifyContent: "start",
+          flexDirection: "row",
+          gap: 10,
+        }}
+      >
+        <View
+          style={{
+            backgroundColor: sbjColor,
+            height: "100%",
+            width: 6,
+            borderRadius: 5,
+          }}
+        />
+        <Typography variant="h4">
+          {getSubjectEmoji(nextCourse.subject)}
+        </Typography>
+        <View
+          style={{
+            flex: 1,
+            gap: 0,
+          }}
+        >
+          <Typography variant="title" numberOfLines={1}>
+            {getSubjectName(nextCourse?.subject)}
+          </Typography>
+
+          {placement === 'inline' ? (
+            <View
+              style={{
+                marginTop: -2,
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                width: "100%",
+                overflow: "hidden",
+              }}
+            >
+              <Icon size={14} fill={sbjColor}>
+                <Papicons name="Clock" />
+              </Icon>
+              <Typography variant="body2" weight="semibold" color={sbjColor} numberOfLines={1}>
+                {formatDistanceToNowStrict(nextCourse.from, {
+                    locale: DateLocale[i18n.language as keyof typeof DateLocale] || DateLocale.enUS,
+                    addSuffix: true
+                  })}
+              </Typography>
+            </View>
+          ) : (
+            <View
+              style={{
+                marginTop: -2,
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 3,
+                width: "100%",
+                overflow: "hidden",
+              }}
+            >
+              <Icon size={14} opacity={0.5}>
+                <Papicons name="MapPin" />
+              </Icon>
+              <Typography variant="body2" weight="semibold" color="textSecondary" numberOfLines={1}>
+                {nextCourse?.room}
+              </Typography>
+              <View style={{ width: 3, height: 3, borderRadius: 8, backgroundColor: theme.colors.text, opacity: 0.5, marginHorizontal: 6 }} />
+              <Icon size={14} opacity={0.5}>
+                <Papicons name="User" />
+              </Icon>
+              <Typography variant="body2" weight="semibold" color="textSecondary" numberOfLines={1}>
+                {nextCourse?.teacher}
+              </Typography>
+            </View>
+          )}
+        </View>
+
+        {placement !== 'inline' && (
+          <View
+            style={{
+              marginTop: -2,
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <Icon size={14} fill={sbjColor}>
+              <Papicons name="Clock" />
+            </Icon>
+            <Typography variant="body1" weight="semibold" color={sbjColor}>
+              {formatDistanceToNowStrict(nextCourse.from, {
+                  locale: DateLocale[i18n.language as keyof typeof DateLocale] || DateLocale.enUS,
+                  addSuffix: false
+                })}
+            </Typography>
+          </View>
+        )}
+      </Pressable>
+
+      <LinearGradient
+        colors={[sbjColor, sbjColor + '00']}
+        start={[1, 0]}
+        end={[0, 0]}
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: "100%",
+          zIndex: -1,
+          opacity: 0.3,
+        }}
+      />
+    </>
+  );
+}
+
+export default function BottomAccessory() {
+  const placement = NativeTabs.BottomAccessory.usePlacement();
+
+  return (
+      <NextCourseAccessory placement={placement} />
+  );
+}

--- a/components/BottomAccessory.tsx
+++ b/components/BottomAccessory.tsx
@@ -12,22 +12,22 @@ import * as DateLocale from 'date-fns/locale';
 import { useNavigation } from 'expo-router';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import React from 'react';
-import { ActivityIndicator, Pressable } from 'react-native';
+import { ActivityIndicator, Platform, Pressable } from 'react-native';
 import { View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 
 function NextCourseAccessory({ placement }) {
+  if (Platform.OS !== 'ios') {
+    return null;
+  }
+
   const theme = useTheme();
   const { courses, loading } = useTimetableWidgetData();
   const nextCourse = courses.length > 0 ? courses[0] : null;
 
-  if(!nextCourse) {
-    return null;
-  }
-
   // if (placement === 'inline') {}
 
-  const sbjColor = getSubjectColor(nextCourse.subject);
+  const sbjColor = nextCourse ? getSubjectColor(nextCourse.subject) : theme.colors.primary;
   const navigation = useNavigation<any>();
 
   if(loading) {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2,7 +2,6 @@
   "Global_Back": "Retour",
   "Global_DatePrefix": "le",
   "Global_Recommended": "Recommandé",
-
   "Tab_Home": "Accueil",
   "Tab_Calendar": "Cours",
   "Tab_Tasks": "Tâches",
@@ -18,7 +17,6 @@
   "Tab_Settings": "Paramètres",
   "Tab_News": "Actualités",
   "Modal_Soon": "Bientôt disponible",
-
   "ONBOARDING_MAIN_TITLE": "L'application pour gérer ta vie scolaire",
   "ONBOARDING_MAIN_DESCRIPTION": "Connecte tes applications scolaires pour accéder à tes notes, cours, devoirs et bien plus dans l'interface Papillon !",
   "ONBOARDING_START_BTN": "Commencer",
@@ -128,7 +126,6 @@
   "ONBOARDING_SERVICE_ARD": "ARD",
   "ONBOARDING_SERVICE_IZLY": "Izly",
   "ONBOARDING_SERVICE_ALISE": "Alise",
-
   "WAITING": "En attente",
   "IZLY_SMS_SEND": "Tu viens de recevoir un lien pour te connecter, clique dessus et suis les étapes.",
   "STEP": "Étape",
@@ -143,27 +140,20 @@
   "LOGIN_BTN": "Se connecter",
   "CONFIRM_BTN": "Confirmer",
   "CANCEL_BTN": "Annuler",
-
   "Tab_New_Event": "Nouvel événement",
-
   "Tab_Calendar_Icals": "Gestion des iCal",
   "Tab_Calendar_Icals_Description": "Gérer tes URL iCal",
-
   "Tab_Calendar_Icals_Add_URL": "Ajouter une URL iCal",
   "Tab_Calendar_Icals_Manage_Title": "Gérer {{title}}",
   "Tab_Calendar_Icals_Manage_Description": "Ajouter ou supprimer des URL iCal à synchroniser avec ton calendrier.",
   "Tab_Calendar_Icals_Add_Title": "Titre manquant",
   "Tab_Calendar_Icals_Add_Description": "Donne un nom à cette URL iCal pour l'ajouter.",
   "Tab_Calendar_Icals_Empty": "Aucune URL iCal ajoutée",
-
   "TabUnderConstruction_Title": "Cet onglet est en construction.",
   "TabUnderConstruction_Details": "Reviens plus tard pour des mises à jour.",
-
   "TabDevModeNotice_Title": "Mode Développement",
   "TabDevModeNotice_Details": "Environnement de test complet pour les développeurs.",
-
   "Alert_TechnicalDetails": "Détails techniques",
-
   "Online_Course": "En ligne",
   "Evaluated_Course": "Évaluation",
   "Edited_Course": "Cours modifié",
@@ -171,36 +161,28 @@
   "No_Course_Room": "Salle inconnue",
   "Event_DeleteEvent": "Supprimer l'événement",
   "Event_Confirm_DeleteEvent": "Es-tu sûr de vouloir supprimer cet événement ?",
-
   "Course_Separator_Lunch_Default": "Pause méridienne",
   "Course_Separator_Lunch_Alt_1": "Bon appétit !",
   "Course_Separator_Lunch_Alt_2": "Miam !",
-
   "Course_Separator_Morning_Default": "Pause matinale",
   "Course_Separator_Morning_Alt_1": "Au dodo !",
   "Course_Separator_Morning_Alt_2": "Petit déjeuner",
-
   "Course_Separator_Evening_Default": "Pause de l'après-midi",
   "Course_Separator_Evening_Alt_1": "Une pause s'impose !",
   "Course_Separator_Evening_Alt_2": "Heure du goûter !",
-
   "Course_Separator_Night_Default": "Pause du soir",
   "Course_Separator_Night_Alt_1": "Au dodo !",
   "Course_Separator_Night_Alt_2": "Il fait nuit !",
-
   "Context_Delete": "Supprimer",
   "Context_Cancel": "Annuler",
   "Context_Edit": "Modifier",
   "Context_Add": "Ajouter",
-
   "Form_Title": "Titre",
   "Form_Location": "Emplacement",
   "Form_Organizer": "Organisateur",
   "Form_Start": "Début",
   "Form_End": "Fin",
-
   "Confirm_DeleteEvent": "Es-tu sûr de vouloir supprimer cet événement ?",
-
   "Home_Welcome_Name": "Bonjour, {{name}} {{emoji}}",
   "Home_Display_More": "Afficher plus",
   "Home_Cards_Button_Description_Plurial": "disponibles",
@@ -211,55 +193,43 @@
   "Home_Planned_None": "Tu n'as aucun cours restant de prévu aujourd'hui",
   "Home_Planned_One": "Tu as un cours restant aujourd'hui",
   "Home_Planned_Number": "Tu as {{number}} cours restants aujourd'hui",
-
   "Home_Widget_NextCourses": "Prochains cours",
   "Home_Widget_NewGrades": "Nouvelles notes",
   "Home_Widget_NewHomeworks": "Tâches à faire",
   "Home_Widget_Grades_Average": "Moyenne",
-
   "Home_Widget_NoCourses": "Aucun cours à venir",
   "Home_Widget_NoCourses_Description": "Il n'y a pas de cours prévus pour aujourd'hui.",
-
   "Home_Cards_Button_Title": "Cartes",
   "Home_Cards_Button_Description_None": "Aucune carte",
   "Home_Cards_Button_Description_Singular": "Une carte",
   "Home_Cards_Button_Description_Number": "{{number}} cartes",
-
   "Home_Chats_Button_Title": "Messages",
   "Home_Chats_Button_Description_None": "Aucun message",
   "Home_Chats_Button_Description_Singular": "Un message",
   "Home_Chats_Button_Description_Number": "{{number}} messages",
-
   "Home_Attendance_Title": "Absences",
   "Home_Attendance_Button_Description_None": "Aucune absence",
   "Home_Attendance_Button_Description_Singular": "Une absence",
   "Home_Attendance_Button_Description_Number": "{{number}} absences",
-
   "Home_Menu_Button_Title": "Menu",
   "Home_Menu_Button_Description": "Menu du jour",
-
   "Home_Release_Notes_Banner": "Nouveautés de la version {{version}}",
   "Home_Release_Notes_Banner_Description": "Découvre les dernières améliorations et corrections de bugs.",
-
   "Tab_Calendar_Empty": "Aucun événement trouvé",
   "Tab_Calendar_Empty_Description": "Ajoute un événement ou synchronise ton calendrier pour commencer.",
-
   "Modal_Course_Title": "Mon cours",
   "Modal_Course_StartsIn": "Commence dans",
   "Modal_Course_StartedAgo": "Terminé il y a",
   "Modal_Course_Ongoing": "Commencé depuis",
   "Modal_Course_Group": "Groupe",
   "Modal_Course_Group_Full": "Classe",
-
   "Modal_Course_Details": "Détails du cours",
   "Modal_Course_Teacher": "Enseignant",
   "Modal_Course_Room": "Salle",
   "Modal_Course_Duration": "Durée",
-
   "Modal_Course_Time": "Horaires du cours",
   "Modal_Course_Start": "Début",
   "Modal_Course_End": "Fin",
-
   "Tasks_Search_Placeholder": "Rechercher des tâches",
   "Tasks_LeftHomeworks_Title": "tâches restantes",
   "Tasks_LeftHomeworks_Time": "cette semaine",
@@ -279,10 +249,8 @@
   "Task_OnlyShowUndone": "Tâches terminées",
   "Task_Show_Title": "Afficher",
   "Settings_General": "Général",
-
   "Latest_Grades": "Nouvelles notes",
   "Grades_Search_Placeholder": "Rechercher une note, une matière",
-
   "Grades_Avg_Methods": "Méthodes de calcul",
   "Grades_Avg_All_Title": "Moyenne générale",
   "Grades_Avg_All_Short": "Moy. générale",
@@ -294,11 +262,9 @@
   "Grades_Avg_Subject_Description": "Calcule la moyenne pondérée des moyennes de matières",
   "Grades_Avg_Median_Title": "Médiane",
   "Grades_Avg_Median_Short": "Médiane",
-
   "Grades_Avg_More": "En savoir plus",
   "Grades_Avg_KnowMore": "En savoir plus",
   "Grades_Avg_KnowMore_Description": "Comprendre les méthodes de calcul de la moyenne générale",
-
   "Grades_SubjectInfo": "Informations sur la matière",
   "Grades_SubjectInfo_NbGrades": "{{number}} note(s)",
   "SubjectInfo_StudentAverage_Label": "Moyenne de l'élève",
@@ -309,57 +275,43 @@
   "SubjectInfo_MaxAverage_Description": "Meilleure moyenne du groupe",
   "SubjectInfo_MinAverage_Label": "Moyenne minimale",
   "SubjectInfo_MinAverage_Description": "Moyenne la plus faible du groupe",
-
   "Grades_Semester": "Semestre",
   "Grades_Trimester": "Trimestre",
   "Grades_OutPeriod": "Hors période",
   "Grades_Year": "Année",
   "Grades_MockExamBac": "Bac blanc",
   "Grades_MockExamBrevet": "Brevet blanc",
-
   "Grades_Method_AllGrades": "Toutes les matières",
   "Grades_Method_Weighted": "Pondération",
-
   "Grades_Sort": "Trier",
   "Grades_Sorting_Alphabetical": "Alphabétique",
   "Grades_Sorting_Averages": "Moyennes",
   "Grades_Sorting_Date": "Date",
-
   "Grades_Menu_SortBy": "Tri par",
   "Grades_Menu_AverageBy": "Moyenne par",
   "NoAverage": "Aucune moyenne",
-
   "Grades_Empty_Title": "Aucune note",
   "Grades_Empty_Description": "Tu n'as pas encore été noté sur cette période.",
-
   "Grade_NoDescription": "Devoir de {{subject}}",
-
   "Grades_Tab_Subjects": "Matières",
   "Grades_Tab_Latest": "Nouvelles notes",
-
   "Profile_Attendance_Title": "Assiduité",
   "Profile_Attendance_Denominator_Single": "absence",
   "Profile_Attendance_Denominator_Plural": "absences",
-
   "Profile_Discussions_Title": "Discussions",
   "Profile_Discussions_Denominator_Single": "non lu",
   "Profile_Discussions_Denominator_Plural": "non lus",
-
   "Profile_News_Title": "Actualités",
   "Profile_News_Denominator_Single": "nouveau",
   "Profile_News_Denominator_Plural": "nouvelles",
   "Profile_News_Open": "Ouvrir",
   "Profile_News_Loading_Title": "Chargement des actualités...",
   "Profile_News_Author_Unknown": "Auteur inconnu",
-
   "Profile_Cards_Title": "QR-Code et cartes",
-
   "Modal_Grades_Title": "Détail de la note",
   "Modal_Grades_BestGrade": "Meilleure note du groupe",
-
   "Modal_Grades_OptionalGrade": "Note optionnelle",
   "Modal_Grades_BonusGrade": "Note bonus",
-
   "Grades_Details_Title": "Détails",
   "Grades_NormalizedGrade_Title": "Note ramenée sur 20",
   "Grades_NormalizedGrade_Description": "Valeur de la note convertie sur une échelle de 20",
@@ -373,19 +325,15 @@
   "Grades_Avg_Group_Short": "Moy. groupe",
   "Grades_Tab_Rank": "Classement",
   "Grades_Tab_Rank_Description": "Position dans le groupe",
-
   "News_Search_Placeholder": "Rechercher une actualité",
   "News_Empty_Title": "Aucune actualité",
   "News_Empty_Description": "Il n'y a pas d'actualités trouvées dans ton établissement.",
   "News_Search_NoResults": "Aucune actualité trouvée",
   "News_Search_NoResults_Description": "Aucune actualité trouvée pour votre recherche.",
-
   "News_Theme_Papillon_Title": "Papillon",
   "News_Theme_Papillon_Description": "Un thème doux et élégant",
-
   "News_Theme_Reading_Title": "Lecture",
   "News_Theme_Reading_Description": "Un thème conçu pour la lecture",
-
   "Attendance_Hours_Missed": "Heures manquées",
   "Attendance_Hours_Unjustified": "Heures injustifiées",
   "Attendance_Hours_Unjustified_Value": "{{duration}} injustifiées",
@@ -401,7 +349,6 @@
   "Attendance_InvalidPeriod": "Période invalide",
   "Attendance_NoEvent_Title": "Aucun événement",
   "Attendance_NoEvent_Description": "Aucune absence ni aucun retard n'a été enregistré pour cette période.",
-
   "Settings_Account_Title": "Mon compte",
   "Settings_Account_Description": "Mon compte",
   "Settings_Services_Title": "Comptes liés",
@@ -433,13 +380,11 @@
   "Settings_Logout_Title": "Se déconnecter",
   "Settings_ReleaseNotes_Title": "Notes de version",
   "Settings_ReleaseNotes_Description": "Quoi de neuf dans cette version ?",
-
   "Settings_Logout_Description": "Supprimer ce compte de Papillon",
   "Settings_Language_Title": "Langue",
   "Settings_Language_Description": "Changer la langue",
   "Settings_Tabs_Title": "Onglets",
   "Settings_Tabs_Description": "Masquer des onglets du menu",
-
   "Settings_Personalization_Title_Card": "Personnalisation",
   "Settings_Personalization_Subtitle_Card": "Thèmes, matières...",
   "Settings_SubjectPersonalization_Title": "Personnaliser les matières",
@@ -466,7 +411,6 @@
   "Settings_About_Issue": "Signaler un bug",
   "Settings_About_Issue_Description": "Reporter un bug rencontré",
   "Settings_About_Dependency_Version": "Version des dépendances",
-
   "Alert_No_Technical": "Aucune information technique disponible.",
   "Alert_Auth_Error": "Erreur d'authentification",
   "Alert_Auth_Bad_Creds": "Les identifiants que tu as saisis sont incorrects ou tu essaies de te connecter avec un compte parent. Ce type de compte n’est pas encore pris en charge par Papillon.",
@@ -476,45 +420,36 @@
   "Alert_Invalid_Instance": "Papillon n'arrive pas à obtenir les informations de cette instance PRONOTE, est-elle encore valide ?",
   "Alert_No_Pos": "Impossible de récupérer la position",
   "Alert_Connexion_Fail": "Connexion impossible",
-
   "Feature_Limited": "Fonctionnalités limitées",
   "Feature_Soon": "Ça arrive bientôt !",
   "Feature_Soon_Notification": "Nous travaillons dur pour vous offrir cette fonctionnalité dans une future mise à jour.",
   "Feature_Add_Card": "Ajoute une nouvelle carte depuis l’onglet Profil accessible dans la barre de navigation",
-
   "Webview_Wait": "Un peu de patience...",
-
   "Profile_QRCards": "QR-Code et cartes",
   "Profile_QRCards_Subtitle": "{{count}} carte(s)",
   "Profile_Cards_Loading_History": "Chargement de l'historique des transactions",
   "Profile_Cards_Loading_History_Description": "Cela peut prendre un moment...",
-
   "Settings_Cards_Banner_Title": "Cartes",
   "Settings_Cantineen_Subtitle_Card": "Cantine, accès",
   "Settings_Cards_Banner_Description": "Ajoute tes cartes de cantine et de transport pour y accéder n'importe où depuis ton téléphone sur Papillon",
   "Settings_Cards_None_Title": "Aucune carte",
   "Settings_Cards_Add_Button": "Ajouter",
-
   "Settings_Cards_None_Description": "Ajoute en-une pour accéder à ton solde de cantine, scanner ton QR-Code et plus encore",
   "Settings_Subjects_None_Title": "Aucune matière",
   "Settings_Subjects_None_Description": "Parcours les différents onglets de l'application afin de pouvoir customiser les matières.",
   "Settings_Subjects_Reset_Title": "Réinitialiser",
   "Settings_Subjects_Reset_Message": "Voulez-vous vraiment réinitialiser toutes les matières ?",
   "Settings_Subjects_Reset_Button": "Réinitialiser",
-
   "Settings_Donator": "Donateurs",
   "Settings_Donator_Description": "Voir la liste des donateurs",
   "Settings_App_Version": "Version de l'application",
-
   "Profile_Cards_Scan_Orientation": "Oriente le QR-Code vers le scanner de la borne",
   "Profile_Cards_No_Reservation": "Aucune réservation",
   "Profile_Cards_No_Available_Reservation": "Il semblerait que tu ne puisses pas réserver ce jour.",
   "Profile_Cards_History": "Historique",
   "Magic_Important": "Peut-être important",
-
   "OnBoarding_Step": "Étape ",
   "OnBoarding_Step_Of": "sur ",
-
   "Consent_Advanced_Title": "Je veux aider Papillon",
   "Consent_Advanced_Description": "On récolte plus d’informations détaillées sur ton utilisation.",
   "Consent_Required_Title": "Juste l'essentiel",
@@ -530,36 +465,28 @@
   "Consent_Arg1": "Sert uniquement à améliorer l’application",
   "Consent_Arg2": "Anonyme & sans lien avec ton identité",
   "Consent_Arg3": "On n'a pas accès à tes comptes",
-
   "Changelog_Title": "Notes de mise à jour",
-
   "Tasks_Sorting_Methods_DueDate": "Date de rendu",
   "Tasks_Sorting_Methods_Subject": "Matières",
   "Tasks_Sorting_Methods_Done": "Non terminé",
   "Tasks_ThisWeek": "Cette semaine",
-
   "Task_Undone": "Non terminé",
   "Task_Done": "Terminé",
-
   "Modal_Wallpaper_Title": "Personnaliser le fond d'écran",
   "Modal_Wallpaper_Clear": "Supprimer le fond d'écran",
   "Modal_Wallpaper_Downloads": "Téléchargements",
   "Modal_Wallpaper_Downloads_Size": "Taille des téléchargements",
   "Modal_Wallpaper_ClearDownloads": "Vider les téléchargements",
   "Modal_Profile_Title": "Personnaliser le profil",
-
   "Modal_Task_Title": "Détail de la tâche",
   "Modal_Task_Status": "État du devoir",
   "Modal_Task_Description": "Description du devoir",
   "Modal_Task_Attachments": "Pièces jointes",
-
   "Today": "Aujourd'hui",
   "Yesterday": "Hier",
   "Tomorrow": "Demain",
-
   "Home_Edit_Profile": "Modifier mon profil",
   "Home_Add_Profile": "Ajouter un profil",
-
   "Settings_Transport_Address_Not_Set": "Non définie",
   "Settings_Transport_Current_Position": "Position actuelle",
   "Settings_Transport_Banner_Title": "Transport",
@@ -571,6 +498,8 @@
   "Settings_Transport_Default_Application_Title": "Application par défaut",
   "Settings_Transport_Title": "Transport",
   "Settings_Transport_Description": "Application de transport, adresses...",
+  "Settings_Features_Title": "Fonctionnalités",
+  "Settings_Features_Description": "Gérer les fonctionnalités de Papillon",
   "Transport_Error_Address_Not_Set_Title": "Aucune adresse n'a été définie",
   "Transport_Error_Address_Not_Set_Description": "Configure tes adresses dans les préférences.",
   "Transport_Error_Cant_Go_To_Current_Location_Title": "Impossible d'afficher cet itinéraire",
@@ -597,7 +526,11 @@
   "Settings_More": "À propos",
   "Settings_About": "Toi et Papillon",
   "Settings_Dev": "Développement",
-
   "Settings_Personalization_Emoji_Picker_Title": "Sélectionne un emoji",
-  "Settings_Personalization_Emoji_Picker_SetEmoji": "Sélectionner"
+  "Settings_Personalization_Emoji_Picker_SetEmoji": "Sélectionner",
+  "Settings_Features_BottomAccessory": "Coup d'oeil",
+  "Settings_Features_BottomAccessory_Description": "Affiche les prochains cours au dessus des onglets",
+  "Settings_Features_ShowTabBarLabels": "Afficher le nom des onglets",
+  "Settings_Features_ShowTabBarLabels_Description": "Indique le nom de l'onglet en dessous de celui-ci",
+  "Settings_Features_TabBar": "Barre d'onglets"
 }

--- a/stores/settings/index.ts
+++ b/stores/settings/index.ts
@@ -15,6 +15,8 @@ const defaultPersonalization: Personalization = {
   colorSelected: Colors.PINK,
   theme: "auto",
   useMaterialYou: DEFAULT_MATERIAL_YOU_ENABLED,
+  iOSBottomAccessoryEnabled: true,
+  showTabBarLabels: true,
   magicEnabled: true,
   hideNameOnHomeScreen: false,
   showAlertAtLogin: false,

--- a/stores/settings/types.ts
+++ b/stores/settings/types.ts
@@ -29,6 +29,8 @@ export interface Personalization {
   colorSelected?: Colors;
   theme?: "light" | "dark" | "auto";
   useMaterialYou?: boolean;
+  iOSBottomAccessoryEnabled?: boolean;
+  showTabBarLabels?: boolean;
   magicEnabled?: boolean;
   hideNameOnHomeScreen?: boolean;
   showAlertAtLogin?: boolean;

--- a/ui/native/NativeSwitch.tsx
+++ b/ui/native/NativeSwitch.tsx
@@ -1,4 +1,4 @@
-import { Platform, Switch } from "react-native"
+import { Platform, Switch, View } from "react-native"
 import { Host, Switch as AndroidSwitch } from '@expo/ui/jetpack-compose';
 
 type NativeSwitchProps = {
@@ -10,13 +10,14 @@ type NativeSwitchProps = {
 const NativeSwitch: React.FC<NativeSwitchProps> = ({ value, onValueChange, disabled }) => {
   if(Platform.OS === "android") {
     return (
-      <Host matchContents>
-        <AndroidSwitch
-          value={value}
-          onCheckedChange={onValueChange}
-          disabled={disabled}
-        />
-      </Host>
+      <View pointerEvents={disabled ? "none" : "auto"}>
+        <Host matchContents>
+          <AndroidSwitch
+            value={value}
+            onCheckedChange={onValueChange}
+          />
+        </Host>
+      </View>
     )
   }
 


### PR DESCRIPTION
Utilisation de l'API [TabViewBottomAccessoryPlacement](https://developer.apple.com/documentation/SwiftUI/TabViewBottomAccessoryPlacement) avec [Expo Router](https://docs.expo.dev/router/advanced/native-tabs/#bottom-accessory) pour afficher le prochain cours en bas de l'écran

| Light mode | Dark mode |
|--------|--------|
| ![IMG_8781](https://github.com/user-attachments/assets/52044bb7-9bed-4e03-9f73-0b9047de7cb3) | ![IMG_8779](https://github.com/user-attachments/assets/c814d68f-e1fe-4749-96a1-12936d54db0d) |
| ![IMG_8780](https://github.com/user-attachments/assets/0843c421-2487-4771-b477-c821690cd578) | ![IMG_8778](https://github.com/user-attachments/assets/3dc2e6a8-b788-4054-baef-ccd2346aa130) | 